### PR TITLE
Dynamically allocated nested API client/server in SSL client/server

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,12 +176,12 @@ set(CMAKE_CXX_FLAGS_DEBUG "-g3 -O0")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-g3 -O3")
 
-if (TULIPS_SANITIZERS)
+if (TULIPS_ENABLE_SANITIZERS)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
   add_link_options(-fsanitize=address)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=undefined")
   add_link_options(-fsanitize=undefined)
-endif (TULIPS_SANITIZERS)
+endif (TULIPS_ENABLE_SANITIZERS)
 
 #
 # Per-compiler options

--- a/apps/ssl_fifo.cpp
+++ b/apps/ssl_fifo.cpp
@@ -19,10 +19,10 @@ enum class ClientState
   Close
 };
 
-class ServerDelegate : public defaults::ServerDelegate
+class ServerDelegate : public api::defaults::ServerDelegate
 {
 public:
-  Action onNewData(UNUSED Server::ID const& id, UNUSED void* const cookie,
+  Action onNewData(UNUSED api::Server::ID const& id, UNUSED void* const cookie,
                    const uint8_t* const data, const uint32_t len) override
   {
     std::string res((const char*)data, len);
@@ -30,7 +30,7 @@ public:
     return Action::Continue;
   }
 
-  Action onNewData(UNUSED Server::ID const& id, UNUSED void* const cookie,
+  Action onNewData(UNUSED api::Server::ID const& id, UNUSED void* const cookie,
                    const uint8_t* const data, const uint32_t len,
                    UNUSED const uint32_t alen, UNUSED uint8_t* const sdata,
                    UNUSED uint32_t& slen) override
@@ -91,13 +91,13 @@ try {
   /*
    * Initialize the client.
    */
-  defaults::ClientDelegate client_delegate;
+  api::defaults::ClientDelegate client_delegate;
   ssl::Client client(logger, client_delegate, cdev, 1, ssl::Protocol::TLS,
                      opts.crt.getValue(), opts.key.getValue());
   /*
    * Open a connection.
    */
-  Client::ID id;
+  api::Client::ID id;
   client.open(id);
   /*
    * Initialize the server

--- a/apps/trc_fifo.cpp
+++ b/apps/trc_fifo.cpp
@@ -27,10 +27,10 @@ static size_t cumul = 0;
  * Server state
  */
 
-class ServerDelegate : public defaults::ServerDelegate
+class ServerDelegate : public api::defaults::ServerDelegate
 {
 public:
-  Action onNewData(UNUSED Server::ID const& id, UNUSED void* const cookie,
+  Action onNewData(UNUSED api::Server::ID const& id, UNUSED void* const cookie,
                    UNUSED const uint8_t* const data,
                    UNUSED const uint32_t len) override
   {
@@ -39,7 +39,7 @@ public:
     return Action::Continue;
   }
 
-  Action onNewData(UNUSED Server::ID const& id, UNUSED void* const cookie,
+  Action onNewData(UNUSED api::Server::ID const& id, UNUSED void* const cookie,
                    UNUSED const uint8_t* const data, UNUSED const uint32_t len,
                    UNUSED const uint32_t alen, UNUSED uint8_t* const sdata,
                    UNUSED uint32_t& slen) override
@@ -141,18 +141,18 @@ try {
   /*
    * Initialize the client.
    */
-  defaults::ClientDelegate client_delegate;
-  Client client(logger, client_delegate, client_dev, 1);
+  api::defaults::ClientDelegate client_delegate;
+  api::Client client(logger, client_delegate, client_dev, 1);
   /*
    * Open a connection.
    */
-  Client::ID id;
+  api::Client::ID id;
   client.open(id);
   /*
    * Initialize the server
    */
-  defaults::ServerDelegate server_delegate;
-  Server server(logger, server_delegate, server_dev, 1);
+  api::defaults::ServerDelegate server_delegate;
+  api::Server server(logger, server_delegate, server_dev, 1);
   server.listen(1234, nullptr);
   /*
    * Set the alarm

--- a/include/tulips/api/Client.h
+++ b/include/tulips/api/Client.h
@@ -16,7 +16,7 @@
 #include <vector>
 #include <unistd.h>
 
-namespace tulips {
+namespace tulips::api {
 
 class Client
   : public interface::Client

--- a/include/tulips/api/Defaults.h
+++ b/include/tulips/api/Defaults.h
@@ -3,7 +3,7 @@
 #include <tulips/api/Client.h>
 #include <tulips/api/Server.h>
 
-namespace tulips::defaults {
+namespace tulips::api::defaults {
 
 class ClientDelegate : public Client::Delegate
 {

--- a/include/tulips/api/Server.h
+++ b/include/tulips/api/Server.h
@@ -14,7 +14,7 @@
 #include <map>
 #include <unistd.h>
 
-namespace tulips {
+namespace tulips::api {
 
 class Server
   : public interface::Server

--- a/include/tulips/ssl/Client.h
+++ b/include/tulips/ssl/Client.h
@@ -76,7 +76,7 @@ private:
   interface::Client::Delegate& m_delegate;
   system::Logger& m_log;
   transport::Device& m_dev;
-  std::unique_ptr<tulips::Client> m_client;
+  std::unique_ptr<tulips::api::Client> m_client;
   void* m_context;
 };
 

--- a/include/tulips/ssl/Client.h
+++ b/include/tulips/ssl/Client.h
@@ -23,11 +23,11 @@ public:
    * Device interface.
    */
 
-  inline Status run() override { return m_client.run(); }
+  inline Status run() override { return m_client->run(); }
 
   inline Status process(const uint16_t len, const uint8_t* const data) override
   {
-    return m_client.process(len, data);
+    return m_client->process(len, data);
   }
 
   /**
@@ -76,7 +76,7 @@ private:
   interface::Client::Delegate& m_delegate;
   system::Logger& m_log;
   transport::Device& m_dev;
-  tulips::Client m_client;
+  std::unique_ptr<tulips::Client> m_client;
   void* m_context;
 };
 

--- a/include/tulips/ssl/Server.h
+++ b/include/tulips/ssl/Server.h
@@ -16,11 +16,11 @@ public:
          const ssl::Protocol type, std::string_view cert, std::string_view key);
   ~Server() override;
 
-  inline Status run() override { return m_server.run(); }
+  inline Status run() override { return m_server->run(); }
 
   inline Status process(const uint16_t len, const uint8_t* const data) override
   {
-    return m_server.process(len, data);
+    return m_server->process(len, data);
   }
 
   Status close(const ID id) override;
@@ -32,12 +32,12 @@ public:
 
   inline void listen(const stack::tcpv4::Port port, void* cookie) override
   {
-    m_server.listen(port, cookie);
+    m_server->listen(port, cookie);
   }
 
   inline void unlisten(const stack::tcpv4::Port port) override
   {
-    m_server.unlisten(port);
+    m_server->unlisten(port);
   }
 
   void* onConnected(ID const& id, void* const cookie, uint8_t& opts) override;
@@ -62,7 +62,7 @@ private:
   interface::Server::Delegate& m_delegate;
   system::Logger& m_log;
   transport::Device& m_dev;
-  api::Server m_server;
+  std::unique_ptr<api::Server> m_server;
   void* m_context;
 };
 

--- a/include/tulips/ssl/Server.h
+++ b/include/tulips/ssl/Server.h
@@ -62,7 +62,7 @@ private:
   interface::Server::Delegate& m_delegate;
   system::Logger& m_log;
   transport::Device& m_dev;
-  tulips::Server m_server;
+  api::Server m_server;
   void* m_context;
 };
 

--- a/src/api/Client.cpp
+++ b/src/api/Client.cpp
@@ -2,7 +2,7 @@
 #include <tulips/stack/ARP.h>
 #include <tulips/system/Compiler.h>
 
-namespace tulips {
+namespace tulips::api {
 
 using namespace stack;
 

--- a/src/api/Defaults.cpp
+++ b/src/api/Defaults.cpp
@@ -1,7 +1,7 @@
 #include <tulips/api/Defaults.h>
 #include <tulips/system/Compiler.h>
 
-namespace tulips::defaults {
+namespace tulips::api::defaults {
 
 void*
 ClientDelegate::onConnected(UNUSED Client::ID const& id,

--- a/src/api/Server.cpp
+++ b/src/api/Server.cpp
@@ -1,7 +1,7 @@
 #include <tulips/api/Server.h>
 #include <arpa/inet.h>
 
-namespace tulips {
+namespace tulips::api {
 
 using namespace stack;
 

--- a/src/apps/TCPLatency.cpp
+++ b/src/apps/TCPLatency.cpp
@@ -53,12 +53,12 @@ enum class State
   Closing
 };
 
-class Delegate : public defaults::ClientDelegate
+class Delegate : public api::defaults::ClientDelegate
 {
 public:
   Delegate(const bool nodelay) : m_nodelay(nodelay) {}
 
-  void* onConnected(UNUSED tulips::Client::ID const& id,
+  void* onConnected(UNUSED tulips::api::Client::ID const& id,
                     UNUSED void* const cookie, uint8_t& opts) override
   {
     opts = m_nodelay ? tcpv4::Connection::NO_DELAY : 0;
@@ -117,7 +117,7 @@ run(Options const& options, transport::Device& base_device)
                                      tulips::ssl::Protocol::TLS,
                                      options.sslCert(), options.sslKey());
   } else {
-    client = new tulips::Client(logger, delegate, *device, 1);
+    client = new tulips::api::Client(logger, delegate, *device, 1);
   }
   /*
    * Set the CPU affinity.
@@ -130,7 +130,7 @@ run(Options const& options, transport::Device& base_device)
   /*
    * Open a connection.
    */
-  tulips::Client::ID id;
+  tulips::api::Client::ID id;
   client->open(id);
   /*
    * Latency timer.
@@ -301,12 +301,12 @@ run(Options const& options, transport::Device& base_device)
 
 namespace Server {
 
-class Delegate : public defaults::ServerDelegate
+class Delegate : public api::defaults::ServerDelegate
 {
 public:
   Delegate() : m_next(0), m_bytes(0) {}
 
-  Action onNewData(UNUSED tulips::Server::ID const& id,
+  Action onNewData(UNUSED tulips::api::Server::ID const& id,
                    UNUSED void* const cookie, const uint8_t* const data,
                    const uint32_t len) override
   {
@@ -320,7 +320,7 @@ public:
     return Action::Continue;
   }
 
-  Action onNewData(UNUSED tulips::Server::ID const& id,
+  Action onNewData(UNUSED tulips::api::Server::ID const& id,
                    UNUSED void* const cookie, const uint8_t* const data,
                    const uint32_t len, UNUSED const uint32_t alen,
                    UNUSED uint8_t* const sdata, UNUSED uint32_t& slen) override
@@ -393,7 +393,7 @@ run(Options const& options, transport::Device& base_device)
       tulips::ssl::Protocol::TLS, options.sslCert(), options.sslKey());
   } else {
     server =
-      new tulips::Server(logger, delegate, *device, options.connections());
+      new tulips::api::Server(logger, delegate, *device, options.connections());
   }
   /*
    * Listen to the local ports.

--- a/src/ssl/Client.cpp
+++ b/src/ssl/Client.cpp
@@ -13,7 +13,7 @@ Client::Client(system::Logger& log, interface::Client::Delegate& delegate,
   : m_delegate(delegate)
   , m_log(log)
   , m_dev(device)
-  , m_client(std::make_unique<tulips::Client>(log, *this, device, nconn))
+  , m_client(std::make_unique<tulips::api::Client>(log, *this, device, nconn))
   , m_context(nullptr)
 {
   m_log.debug("SSLCLI", "protocol: ", ssl::toString(type));

--- a/tests/api/one_client.cpp
+++ b/tests/api/one_client.cpp
@@ -14,12 +14,12 @@ using namespace stack;
 
 namespace {
 
-class ServerDelegate : public defaults::ServerDelegate
+class ServerDelegate : public api::defaults::ServerDelegate
 {
 public:
   ServerDelegate() : m_listenCookie(0), m_action(Action::Continue), m_opts(0) {}
 
-  void* onConnected(UNUSED Server::ID const& id, void* const cookie,
+  void* onConnected(UNUSED api::Server::ID const& id, void* const cookie,
                     uint8_t& opts) override
   {
     if (cookie != nullptr) {
@@ -29,7 +29,7 @@ public:
     return nullptr;
   }
 
-  Action onNewData(UNUSED Server::ID const& id, UNUSED void* const cookie,
+  Action onNewData(UNUSED api::Server::ID const& id, UNUSED void* const cookie,
                    UNUSED const uint8_t* const data, UNUSED const uint32_t len,
                    UNUSED const uint32_t alen, UNUSED uint8_t* const sdata,
                    UNUSED uint32_t& slen) override
@@ -114,11 +114,11 @@ protected:
     /*
      * Create the client.
      */
-    m_client = new Client(m_logger, m_client_delegate, *m_client_pcap, 2);
+    m_client = new api::Client(m_logger, m_client_delegate, *m_client_pcap, 2);
     /*
      * Create the server.
      */
-    m_server = new Server(m_logger, m_server_delegate, *m_server_pcap, 2);
+    m_server = new api::Server(m_logger, m_server_delegate, *m_server_pcap, 2);
   }
 
   void TearDown() override
@@ -158,17 +158,17 @@ protected:
   transport::list::Device* m_server_ldev;
   transport::pcap::Device* m_client_pcap;
   transport::pcap::Device* m_server_pcap;
-  defaults::ClientDelegate m_client_delegate;
-  Client* m_client;
+  api::defaults::ClientDelegate m_client_delegate;
+  api::Client* m_client;
   ServerDelegate m_server_delegate;
-  Server* m_server;
+  api::Server* m_server;
 };
 
 TEST_F(API_OneClient, OpenClose)
 {
-  Client::ID id1 = Client::DEFAULT_ID;
-  Client::ID id2 = Client::DEFAULT_ID;
-  Client::ID id3 = Client::DEFAULT_ID;
+  api::Client::ID id1 = api::Client::DEFAULT_ID;
+  api::Client::ID id2 = api::Client::DEFAULT_ID;
+  api::Client::ID id3 = api::Client::DEFAULT_ID;
   ASSERT_EQ(Status::Ok, m_client->open(id1));
   ASSERT_EQ(Status::Ok, m_client->open(id2));
   ASSERT_EQ(Status::NoMoreResources, m_client->open(id3));
@@ -178,7 +178,7 @@ TEST_F(API_OneClient, OpenClose)
 
 TEST_F(API_OneClient, ListenConnectAndAbort)
 {
-  Client::ID id = Client::DEFAULT_ID;
+  api::Client::ID id = api::Client::DEFAULT_ID;
   ipv4::Address dst_ip(10, 1, 0, 2);
   // Server listens
   m_server->listen(12345, nullptr);
@@ -210,7 +210,7 @@ TEST_F(API_OneClient, ListenConnectAndAbort)
 
 TEST_F(API_OneClient, ListenConnectAndClose)
 {
-  Client::ID id = Client::DEFAULT_ID;
+  api::Client::ID id = api::Client::DEFAULT_ID;
   ipv4::Address dst_ip(10, 1, 0, 2);
   // Server listens
   m_server->listen(12345, nullptr);
@@ -259,7 +259,7 @@ TEST_F(API_OneClient, ListenConnectAndClose)
 
 TEST_F(API_OneClient, ListenConnectAndCloseFromServer)
 {
-  Client::ID id = Client::DEFAULT_ID;
+  api::Client::ID id = api::Client::DEFAULT_ID;
   ipv4::Address dst_ip(10, 1, 0, 2);
   /*
    * Server listens
@@ -308,7 +308,7 @@ TEST_F(API_OneClient, ListenConnectAndCloseFromServer)
 
 TEST_F(API_OneClient, ConnectCookie)
 {
-  Client::ID id = Client::DEFAULT_ID;
+  api::Client::ID id = api::Client::DEFAULT_ID;
   size_t cookie = 0xdeadbeef;
   ipv4::Address dst_ip(10, 1, 0, 2);
   /*
@@ -335,7 +335,7 @@ TEST_F(API_OneClient, ConnectCookie)
 
 TEST_F(API_OneClient, ConnectTwo)
 {
-  Client::ID id1 = Client::DEFAULT_ID, id2 = Client::DEFAULT_ID;
+  api::Client::ID id1 = api::Client::DEFAULT_ID, id2 = api::Client::DEFAULT_ID;
   size_t cookie = 0xdeadbeef;
   ipv4::Address dst_ip(10, 1, 0, 2);
   /*
@@ -372,7 +372,7 @@ TEST_F(API_OneClient, ConnectTwo)
 
 TEST_F(API_OneClient, ConnectAndCloseTwo)
 {
-  Client::ID id1 = Client::DEFAULT_ID, id2 = Client::DEFAULT_ID;
+  api::Client::ID id1 = api::Client::DEFAULT_ID, id2 = api::Client::DEFAULT_ID;
   size_t cookie = 0xdeadbeef;
   ipv4::Address dst_ip(10, 1, 0, 2);
   /*
@@ -437,7 +437,7 @@ TEST_F(API_OneClient, ConnectAndCloseTwo)
 
 TEST_F(API_OneClient, ListenConnectSendAndAbortFromServer)
 {
-  Client::ID id = Client::DEFAULT_ID;
+  api::Client::ID id = api::Client::DEFAULT_ID;
   ipv4::Address dst_ip(10, 1, 0, 2);
   /*
    * Server listens.
@@ -479,7 +479,7 @@ TEST_F(API_OneClient, ListenConnectSendAndAbortFromServer)
 
 TEST_F(API_OneClient, ListenConnectSendAndAbortFromServerWithDelayedACK)
 {
-  Client::ID id = Client::DEFAULT_ID;
+  api::Client::ID id = api::Client::DEFAULT_ID;
   ipv4::Address dst_ip(10, 1, 0, 2);
   /*
    * Server listens.

--- a/tests/api/two_clients.cpp
+++ b/tests/api/two_clients.cpp
@@ -13,12 +13,12 @@ using namespace stack;
 
 namespace {
 
-class ClientDelegate : public defaults::ClientDelegate
+class ClientDelegate : public api::defaults::ClientDelegate
 {
 public:
   ClientDelegate() : m_data_received(false) {}
 
-  tulips::Action onNewData(UNUSED Client::ID const& id,
+  tulips::Action onNewData(UNUSED api::Client::ID const& id,
                            UNUSED void* const cookie,
                            UNUSED const uint8_t* const data,
                            UNUSED const uint32_t len) override
@@ -27,7 +27,7 @@ public:
     return tulips::Action::Continue;
   }
 
-  tulips::Action onNewData(UNUSED Client::ID const& id,
+  tulips::Action onNewData(UNUSED api::Client::ID const& id,
                            UNUSED void* const cookie,
                            UNUSED const uint8_t* const data,
                            UNUSED const uint32_t len,
@@ -45,21 +45,21 @@ private:
   bool m_data_received;
 };
 
-class ServerDelegate : public defaults::ServerDelegate
+class ServerDelegate : public api::defaults::ServerDelegate
 {
 public:
-  using Connections = std::list<tulips::Server::ID>;
+  using Connections = std::list<tulips::api::Server::ID>;
 
   ServerDelegate() : m_connections(), m_send_back(false) {}
 
-  void* onConnected(Server::ID const& id, UNUSED void* const cookie,
+  void* onConnected(api::Server::ID const& id, UNUSED void* const cookie,
                     UNUSED uint8_t& opts) override
   {
     m_connections.push_back(id);
     return nullptr;
   }
 
-  Action onNewData(UNUSED Server::ID const& id, UNUSED void* const cookie,
+  Action onNewData(UNUSED api::Server::ID const& id, UNUSED void* const cookie,
                    const uint8_t* const data, const uint32_t len,
                    const uint32_t alen, uint8_t* const sdata,
                    uint32_t& slen) override
@@ -71,7 +71,7 @@ public:
     return Action::Continue;
   }
 
-  void onClosed(tulips::Server::ID const& id,
+  void onClosed(tulips::api::Server::ID const& id,
                 UNUSED void* const cookie) override
   {
     m_connections.remove(id);
@@ -139,12 +139,14 @@ protected:
     /*
      * Create the clients.
      */
-    m_client1 = new Client(m_logger, m_client_delegate1, *m_client_pcap, 1);
-    m_client2 = new Client(m_logger, m_client_delegate2, *m_client_pcap, 1);
+    m_client1 =
+      new api::Client(m_logger, m_client_delegate1, *m_client_pcap, 1);
+    m_client2 =
+      new api::Client(m_logger, m_client_delegate2, *m_client_pcap, 1);
     /*
      * Create the server.
      */
-    m_server = new Server(m_logger, m_server_delegate, *m_server_pcap, 2);
+    m_server = new api::Server(m_logger, m_server_delegate, *m_server_pcap, 2);
     /*
      * Server listens.
      */
@@ -184,15 +186,15 @@ protected:
   transport::pcap::Device* m_server_pcap;
   ClientDelegate m_client_delegate1;
   ClientDelegate m_client_delegate2;
-  Client* m_client1;
-  Client* m_client2;
+  api::Client* m_client1;
+  api::Client* m_client2;
   ServerDelegate m_server_delegate;
-  Server* m_server;
+  api::Server* m_server;
 };
 
 TEST_F(API_TwoClients, ConnectTwo)
 {
-  Client::ID id1 = Client::DEFAULT_ID, id2 = Client::DEFAULT_ID;
+  api::Client::ID id1 = api::Client::DEFAULT_ID, id2 = api::Client::DEFAULT_ID;
   ipv4::Address dst_ip(10, 1, 0, 2);
   /*
    * Connection client 1.
@@ -231,7 +233,7 @@ TEST_F(API_TwoClients, ConnectTwo)
 
 TEST_F(API_TwoClients, ConnectTwoAndDisconnectFromServer)
 {
-  Client::ID id1 = Client::DEFAULT_ID, id2 = Client::DEFAULT_ID;
+  api::Client::ID id1 = api::Client::DEFAULT_ID, id2 = api::Client::DEFAULT_ID;
   ipv4::Address dst_ip(10, 1, 0, 2);
   /*
    * Connection client 1.
@@ -269,7 +271,7 @@ TEST_F(API_TwoClients, ConnectTwoAndDisconnectFromServer)
    * Disconnect the first connection.
    */
   ASSERT_EQ(2, m_server_delegate.connections().size());
-  tulips::Server::ID c0 = m_server_delegate.connections().front();
+  tulips::api::Server::ID c0 = m_server_delegate.connections().front();
   ASSERT_EQ(Status::Ok, m_server->close(c0));
   ASSERT_EQ(Status::Ok, m_client_pcap->poll(*m_client1));
   ASSERT_EQ(Status::Ok, m_server_pcap->poll(*m_server));
@@ -280,7 +282,7 @@ TEST_F(API_TwoClients, ConnectTwoAndDisconnectFromServer)
    * Disconnect the second connection.
    */
   ASSERT_EQ(1, m_server_delegate.connections().size());
-  tulips::Server::ID c1 = m_server_delegate.connections().front();
+  tulips::api::Server::ID c1 = m_server_delegate.connections().front();
   ASSERT_EQ(Status::Ok, m_server->close(c1));
   ASSERT_EQ(Status::Ok, m_client_pcap->poll(*m_client2));
   ASSERT_EQ(Status::Ok, m_server_pcap->poll(*m_server));
@@ -295,7 +297,7 @@ TEST_F(API_TwoClients, ConnectTwoAndDisconnectFromServer)
 
 TEST_F(API_TwoClients, ConnectSend)
 {
-  Client::ID id = Client::DEFAULT_ID;
+  api::Client::ID id = api::Client::DEFAULT_ID;
   ipv4::Address dst_ip(10, 1, 0, 2);
   /*
    * Connect client.
@@ -329,7 +331,7 @@ TEST_F(API_TwoClients, ConnectSend)
 
 TEST_F(API_TwoClients, ConnectSendReceive)
 {
-  Client::ID id = Client::DEFAULT_ID;
+  api::Client::ID id = api::Client::DEFAULT_ID;
   ipv4::Address dst_ip(10, 1, 0, 2);
   /*
    * Ask the server to send the data back.

--- a/tests/ssl/one_client.cpp
+++ b/tests/ssl/one_client.cpp
@@ -14,12 +14,12 @@ using namespace stack;
 
 namespace {
 
-class ServerDelegate : public defaults::ServerDelegate
+class ServerDelegate : public api::defaults::ServerDelegate
 {
 public:
   ServerDelegate() : m_action(Action::Continue) {}
 
-  tulips::Action onNewData(UNUSED Client::ID const& id,
+  tulips::Action onNewData(UNUSED api::Client::ID const& id,
                            UNUSED void* const cookie, const uint8_t* const data,
                            UNUSED const uint32_t len,
                            UNUSED const uint32_t alen,
@@ -62,7 +62,7 @@ public:
   {}
 
   void connectClient(ipv4::Address const& dst_ip, const uint16_t port,
-                     Client::ID& id)
+                     api::Client::ID& id)
   {
     /*
      * Client opens a connection.
@@ -183,7 +183,7 @@ protected:
   transport::list::Device* m_server_ldev;
   transport::pcap::Device* m_client_pcap;
   transport::pcap::Device* m_server_pcap;
-  defaults::ClientDelegate m_client_delegate;
+  api::defaults::ClientDelegate m_client_delegate;
   ssl::Client* m_client;
   ServerDelegate m_server_delegate;
   ssl::Server* m_server;
@@ -191,7 +191,7 @@ protected:
 
 TEST_F(SSL_OneClient, ListenConnectAndAbort)
 {
-  Client::ID id = Client::DEFAULT_ID;
+  api::Client::ID id = api::Client::DEFAULT_ID;
   ipv4::Address dst_ip(10, 1, 0, 2);
   /*
    * Server listens
@@ -216,7 +216,7 @@ TEST_F(SSL_OneClient, ListenConnectAndAbort)
 
 TEST_F(SSL_OneClient, ListenConnectAndClose)
 {
-  Client::ID id = Client::DEFAULT_ID;
+  api::Client::ID id = api::Client::DEFAULT_ID;
   ipv4::Address dst_ip(10, 1, 0, 2);
   /*
    * Server listens
@@ -252,7 +252,7 @@ TEST_F(SSL_OneClient, ListenConnectAndClose)
 
 TEST_F(SSL_OneClient, ListenConnectAndCloseFromServer)
 {
-  Client::ID id = Client::DEFAULT_ID;
+  api::Client::ID id = api::Client::DEFAULT_ID;
   ipv4::Address dst_ip(10, 1, 0, 2);
   /*
    * Server listens
@@ -288,7 +288,7 @@ TEST_F(SSL_OneClient, ListenConnectAndCloseFromServer)
 
 TEST_F(SSL_OneClient, ListenConnectSendAndAbortFromServer)
 {
-  Client::ID id = Client::DEFAULT_ID;
+  api::Client::ID id = api::Client::DEFAULT_ID;
   ipv4::Address dst_ip(10, 1, 0, 2);
   /*
    * Server listens
@@ -319,7 +319,7 @@ TEST_F(SSL_OneClient, ListenConnectSendAndAbortFromServer)
 
 TEST_F(SSL_OneClient, ListenConnectSendAndCloseFromServer)
 {
-  Client::ID id = Client::DEFAULT_ID;
+  api::Client::ID id = api::Client::DEFAULT_ID;
   ipv4::Address dst_ip(10, 1, 0, 2);
   /*
    * Server listens

--- a/tests/ssl/two_clients.cpp
+++ b/tests/ssl/two_clients.cpp
@@ -13,12 +13,12 @@ using namespace stack;
 
 namespace {
 
-class ClientDelegate : public defaults::ClientDelegate
+class ClientDelegate : public api::defaults::ClientDelegate
 {
 public:
   ClientDelegate() : m_data_received(false) {}
 
-  tulips::Action onNewData(UNUSED Client::ID const& id,
+  tulips::Action onNewData(UNUSED api::Client::ID const& id,
                            UNUSED void* const cookie,
                            UNUSED const uint8_t* const data,
                            UNUSED const uint32_t len) override
@@ -27,7 +27,7 @@ public:
     return tulips::Action::Continue;
   }
 
-  tulips::Action onNewData(UNUSED Client::ID const& id,
+  tulips::Action onNewData(UNUSED api::Client::ID const& id,
                            UNUSED void* const cookie,
                            UNUSED const uint8_t* const data,
                            UNUSED const uint32_t len,
@@ -45,21 +45,21 @@ private:
   bool m_data_received;
 };
 
-class ServerDelegate : public defaults::ServerDelegate
+class ServerDelegate : public api::defaults::ServerDelegate
 {
 public:
-  using Connections = std::list<tulips::Server::ID>;
+  using Connections = std::list<tulips::api::Server::ID>;
 
   ServerDelegate() : m_connections(), m_send_back(false) {}
 
-  void* onConnected(Server::ID const& id, UNUSED void* const cookie,
+  void* onConnected(api::Server::ID const& id, UNUSED void* const cookie,
                     UNUSED uint8_t& opts) override
   {
     m_connections.push_back(id);
     return nullptr;
   }
 
-  Action onNewData(UNUSED Server::ID const& id, UNUSED void* const cookie,
+  Action onNewData(UNUSED api::Server::ID const& id, UNUSED void* const cookie,
                    const uint8_t* const data, const uint32_t len,
                    const uint32_t alen, uint8_t* const sdata,
                    uint32_t& slen) override
@@ -71,7 +71,7 @@ public:
     return Action::Continue;
   }
 
-  void onClosed(tulips::Server::ID const& id,
+  void onClosed(tulips::api::Server::ID const& id,
                 UNUSED void* const cookie) override
   {
     m_connections.remove(id);
@@ -110,7 +110,7 @@ public:
   {}
 
   void connectClient(ipv4::Address const& dst_ip, const int port,
-                     Client::ID& id)
+                     api::Client::ID& id)
   {
     /*
      * Client tries to connect, establish a connection.
@@ -139,7 +139,7 @@ public:
     ASSERT_EQ(Status::NoDataAvailable, m_server_pcap->poll(*m_server));
   }
 
-  void abortClient(const Client::ID& id)
+  void abortClient(const api::Client::ID& id)
   {
     /*
      * Client tries to close.
@@ -154,7 +154,7 @@ public:
     ASSERT_EQ(Status::NoDataAvailable, m_server_pcap->poll(*m_server));
   }
 
-  void disconnectClient(const Client::ID& id)
+  void disconnectClient(const api::Client::ID& id)
   {
     /*
      * Client tries to close.
@@ -176,7 +176,7 @@ public:
   }
 
   void connect1stClient(ipv4::Address const& dst_ip, const int port,
-                        Client::ID& id)
+                        api::Client::ID& id)
   {
     ASSERT_EQ(Status::Ok, m_client->open(id));
     /*
@@ -192,7 +192,7 @@ public:
   }
 
   void connect2ndClient(ipv4::Address const& dst_ip, const int port,
-                        Client::ID& id)
+                        api::Client::ID& id)
   {
     ASSERT_EQ(Status::Ok, m_client->open(id));
     /*
@@ -201,7 +201,7 @@ public:
     connectClient(dst_ip, port, id);
   }
 
-  void disconnectClientFromServer(const Server::ID id)
+  void disconnectClientFromServer(const api::Server::ID id)
   {
     ASSERT_EQ(Status::OperationInProgress, m_server->close(id));
     ASSERT_EQ(Status::Ok, m_client_pcap->poll(*m_client));
@@ -311,7 +311,7 @@ protected:
 
 TEST_F(SSL_TwoClients, ConnectTwoAndAbort)
 {
-  Client::ID id[2] = { Client::DEFAULT_ID, Client::DEFAULT_ID };
+  api::Client::ID id[2] = { api::Client::DEFAULT_ID, api::Client::DEFAULT_ID };
   ipv4::Address dst_ip(10, 1, 0, 2);
   /*
    * Connect the clients.
@@ -333,7 +333,7 @@ TEST_F(SSL_TwoClients, ConnectTwoAndAbort)
 
 TEST_F(SSL_TwoClients, ConnectTwoAndClose)
 {
-  Client::ID id[2] = { Client::DEFAULT_ID, Client::DEFAULT_ID };
+  api::Client::ID id[2] = { api::Client::DEFAULT_ID, api::Client::DEFAULT_ID };
   ipv4::Address dst_ip(10, 1, 0, 2);
   /*
    * Connect the clients.
@@ -355,7 +355,7 @@ TEST_F(SSL_TwoClients, ConnectTwoAndClose)
 
 TEST_F(SSL_TwoClients, ConnectTwoAndCloseFromServer)
 {
-  Client::ID id[2] = { Client::DEFAULT_ID, Client::DEFAULT_ID };
+  api::Client::ID id[2] = { api::Client::DEFAULT_ID, api::Client::DEFAULT_ID };
   ipv4::Address dst_ip(10, 1, 0, 2);
   /*
    * Connect the clients.
@@ -366,20 +366,20 @@ TEST_F(SSL_TwoClients, ConnectTwoAndCloseFromServer)
   /*
    * Disconnect the first connection.
    */
-  tulips::Server::ID c0 = m_server_delegate.connections().front();
+  tulips::api::Server::ID c0 = m_server_delegate.connections().front();
   disconnectClientFromServer(c0);
   ASSERT_EQ(1, m_server_delegate.connections().size());
   /*
    * Disconnect the second connection.
    */
-  tulips::Server::ID c1 = m_server_delegate.connections().front();
+  tulips::api::Server::ID c1 = m_server_delegate.connections().front();
   disconnectClientFromServer(c1);
   ASSERT_EQ(0, m_server_delegate.connections().size());
 }
 
 TEST_F(SSL_TwoClients, ConnectSendAndClose)
 {
-  Client::ID id = Client::DEFAULT_ID;
+  api::Client::ID id = api::Client::DEFAULT_ID;
   ipv4::Address dst_ip(10, 1, 0, 2);
   /*
    * Connect client.
@@ -405,7 +405,7 @@ TEST_F(SSL_TwoClients, ConnectSendAndClose)
 
 TEST_F(SSL_TwoClients, ConnectSendReceiveAndClose)
 {
-  Client::ID id = Client::DEFAULT_ID;
+  api::Client::ID id = api::Client::DEFAULT_ID;
   ipv4::Address dst_ip(10, 1, 0, 2);
   /*
    * Ask the server to send the data back.

--- a/tools/uspace/ena/Connection.cpp
+++ b/tools/uspace/ena/Connection.cpp
@@ -58,7 +58,7 @@ public:
     /*
      * Create a connection.
      */
-    Client::ID id;
+    api::Client::ID id;
     switch (s.pollers[poller]->connect(ip, port, id)) {
       case Status::Ok: {
         std::cout << "OK - " << id << std::endl;
@@ -111,7 +111,7 @@ public:
     /*
      * Parse the port socket.
      */
-    Client::ID c;
+    api::Client::ID c;
     std::istringstream(args[1]) >> c;
     /*
      * Check if the connection exists.
@@ -225,7 +225,7 @@ public:
     /*
      * Parse the port socket.
      */
-    Client::ID id;
+    api::Client::ID id;
     std::istringstream(args[1]) >> id;
     /*
      * Check if the connection exists.

--- a/tools/uspace/ena/Poller.cpp
+++ b/tools/uspace/ena/Poller.cpp
@@ -54,7 +54,7 @@ Poller::~Poller()
 
 Status
 Poller::connect(stack::ipv4::Address const& ripaddr,
-                const stack::tcpv4::Port rport, Client::ID& id)
+                const stack::tcpv4::Port rport, api::Client::ID& id)
 {
   Status result;
   pthread_mutex_lock(&m_mutex);
@@ -83,7 +83,7 @@ Poller::connect(stack::ipv4::Address const& ripaddr,
 }
 
 Status
-Poller::close(const Client::ID id)
+Poller::close(const api::Client::ID id)
 {
   Status result;
   pthread_mutex_lock(&m_mutex);
@@ -102,7 +102,7 @@ Poller::close(const Client::ID id)
 }
 
 Status
-Poller::get(const Client::ID id, stack::ipv4::Address& ripaddr,
+Poller::get(const api::Client::ID id, stack::ipv4::Address& ripaddr,
             stack::tcpv4::Port& lport, stack::tcpv4::Port& rport)
 {
   Status result;
@@ -125,7 +125,7 @@ Poller::get(const Client::ID id, stack::ipv4::Address& ripaddr,
 }
 
 Status
-Poller::write(const Client::ID id, std::string_view data)
+Poller::write(const api::Client::ID id, std::string_view data)
 {
   Status result;
   pthread_mutex_lock(&m_mutex);

--- a/tools/uspace/ena/Poller.h
+++ b/tools/uspace/ena/Poller.h
@@ -23,14 +23,14 @@ public:
   ~Poller();
 
   Status connect(stack::ipv4::Address const& ripaddr,
-                 const stack::tcpv4::Port rport, Client::ID& id);
+                 const stack::tcpv4::Port rport, api::Client::ID& id);
 
-  Status close(const Client::ID id);
+  Status close(const api::Client::ID id);
 
-  Status get(const Client::ID id, stack::ipv4::Address& ripaddr,
+  Status get(const api::Client::ID id, stack::ipv4::Address& ripaddr,
              stack::tcpv4::Port& lport, stack::tcpv4::Port& rport);
 
-  Status write(const Client::ID id, std::string_view data);
+  Status write(const api::Client::ID id, std::string_view data);
 
 private:
   enum class Action
@@ -55,8 +55,8 @@ private:
   transport::Device::Ref m_dev;
   transport::pcap::Device* m_pcap;
   transport::Device* m_device;
-  defaults::ClientDelegate m_delegate;
-  Client m_client;
+  api::defaults::ClientDelegate m_delegate;
+  api::Client m_client;
   volatile bool m_run;
   pthread_t m_thread;
   pthread_mutex_t m_mutex;
@@ -65,7 +65,7 @@ private:
   stack::ipv4::Address m_ripaddr;
   stack::tcpv4::Port m_lport;
   stack::tcpv4::Port m_rport;
-  Client::ID m_id;
+  api::Client::ID m_id;
   Status m_status;
   std::string m_data;
 };

--- a/tools/uspace/ena/State.h
+++ b/tools/uspace/ena/State.h
@@ -10,7 +10,7 @@
 
 namespace tulips::tools::uspace::ena {
 
-using IDs = std::map<Client::ID, size_t>;
+using IDs = std::map<api::Client::ID, size_t>;
 
 class State : public utils::State
 {

--- a/tools/uspace/ofed/Connection.cpp
+++ b/tools/uspace/ofed/Connection.cpp
@@ -35,7 +35,7 @@ public:
     /*
      * Parse the port socket.
      */
-    Client::ID c;
+    api::Client::ID c;
     std::istringstream(args[1]) >> c;
     /*
      * Check if the connection exists.
@@ -111,7 +111,7 @@ public:
     /*
      * Create a connection.
      */
-    Client::ID id;
+    api::Client::ID id;
     switch (s.poller.connect(ip, port, id)) {
       case Status::Ok: {
         std::cout << "OK - " << id << std::endl;
@@ -209,7 +209,7 @@ public:
     /*
      * Parse the port socket.
      */
-    Client::ID id;
+    api::Client::ID id;
     std::istringstream(args[1]) >> id;
     /*
      * Check if the connection exists.

--- a/tools/uspace/ofed/Poller.cpp
+++ b/tools/uspace/ofed/Poller.cpp
@@ -69,7 +69,7 @@ Poller::~Poller()
 
 Status
 Poller::connect(stack::ipv4::Address const& ripaddr,
-                const stack::tcpv4::Port rport, Client::ID& id)
+                const stack::tcpv4::Port rport, api::Client::ID& id)
 {
   Status result;
   pthread_mutex_lock(&m_mutex);
@@ -98,7 +98,7 @@ Poller::connect(stack::ipv4::Address const& ripaddr,
 }
 
 Status
-Poller::close(const Client::ID id)
+Poller::close(const api::Client::ID id)
 {
   Status result;
   pthread_mutex_lock(&m_mutex);
@@ -117,7 +117,7 @@ Poller::close(const Client::ID id)
 }
 
 Status
-Poller::get(const Client::ID id, stack::ipv4::Address& ripaddr,
+Poller::get(const api::Client::ID id, stack::ipv4::Address& ripaddr,
             stack::tcpv4::Port& lport, stack::tcpv4::Port& rport)
 {
   Status result;
@@ -140,7 +140,7 @@ Poller::get(const Client::ID id, stack::ipv4::Address& ripaddr,
 }
 
 Status
-Poller::write(const Client::ID id, std::string_view data)
+Poller::write(const api::Client::ID id, std::string_view data)
 {
   Status result;
   pthread_mutex_lock(&m_mutex);

--- a/tools/uspace/ofed/Poller.h
+++ b/tools/uspace/ofed/Poller.h
@@ -16,14 +16,14 @@ public:
   ~Poller();
 
   Status connect(stack::ipv4::Address const& ripaddr,
-                 const stack::tcpv4::Port rport, Client::ID& id);
+                 const stack::tcpv4::Port rport, api::Client::ID& id);
 
-  Status close(const Client::ID id);
+  Status close(const api::Client::ID id);
 
-  Status get(const Client::ID id, stack::ipv4::Address& ripaddr,
+  Status get(const api::Client::ID id, stack::ipv4::Address& ripaddr,
              stack::tcpv4::Port& lport, stack::tcpv4::Port& rport);
 
-  Status write(const Client::ID id, std::string_view data);
+  Status write(const api::Client::ID id, std::string_view data);
 
 private:
   enum class Action
@@ -48,8 +48,8 @@ private:
   transport::ofed::Device m_ofed;
   transport::pcap::Device* m_pcap;
   transport::Device* m_device;
-  defaults::ClientDelegate m_delegate;
-  Client m_client;
+  api::defaults::ClientDelegate m_delegate;
+  api::Client m_client;
   volatile bool m_run;
   pthread_t m_thread;
   pthread_mutex_t m_mutex;
@@ -58,7 +58,7 @@ private:
   stack::ipv4::Address m_ripaddr;
   stack::tcpv4::Port m_lport;
   stack::tcpv4::Port m_rport;
-  Client::ID m_id;
+  api::Client::ID m_id;
   Status m_status;
   std::string m_data;
 };

--- a/tools/uspace/ofed/State.h
+++ b/tools/uspace/ofed/State.h
@@ -7,7 +7,7 @@
 
 namespace tulips::tools::uspace::ofed {
 
-using IDs = std::set<Client::ID>;
+using IDs = std::set<api::Client::ID>;
 
 struct State : public utils::State
 {


### PR DESCRIPTION
For some reason, when allocating the client on the stack, we get a strange memory corruption in Rust. None of the sanitizer are able to detect it, but using a smart pointer seems to help.