### PR TITLE
Fix segment buffer overwrite, memory leaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ EXTFLAGS ?=
 
 .PHONY: build
 
-default: release
+default: build
 
 build:
 	@[ -e $(BUILDDIR) ] && ninja -C $(BUILDDIR) -j $(NPROCS)
@@ -53,4 +53,5 @@ release-lib:
 
 clean:
 	@rm -rf $(BUILDDIR)
+	@rm -f *.keys *.log *.pcap
 

--- a/apps/raw_ofed.cpp
+++ b/apps/raw_ofed.cpp
@@ -5,6 +5,7 @@
 #include <tulips/transport/ofed/Device.h>
 #include <tulips/transport/pcap/Device.h>
 #include <csignal>
+#include <cstdint>
 #include <pthread.h>
 #include <tclap/CmdLine.h>
 
@@ -50,6 +51,8 @@ public:
     value += 1;
     return send(sizeof(value), (uint8_t*)&value, true);
   }
+
+  Status sent(uint8_t* const data) override { return m_ethto->release(data); }
 
   Status send(const uint16_t len, const uint8_t* const data,
               const bool swap = false)

--- a/apps/raw_ofed.cpp
+++ b/apps/raw_ofed.cpp
@@ -52,7 +52,10 @@ public:
     return send(sizeof(value), (uint8_t*)&value, true);
   }
 
-  Status sent(uint8_t* const data) override { return m_ethto->release(data); }
+  Status sent(UNUSED const uint16_t len, uint8_t* const data) override
+  {
+    return m_ethto->release(data);
+  }
 
   Status send(const uint16_t len, const uint8_t* const data,
               const bool swap = false)

--- a/apps/ssl_fifo.cpp
+++ b/apps/ssl_fifo.cpp
@@ -1,8 +1,8 @@
-#include "tulips/system/Logger.h"
 #include <tulips/api/Defaults.h>
 #include <tulips/ssl/Client.h>
 #include <tulips/ssl/Server.h>
 #include <tulips/system/Compiler.h>
+#include <tulips/system/Logger.h>
 #include <tulips/transport/pcap/Device.h>
 #include <tulips/transport/shm/Device.h>
 #include <iostream>

--- a/apps/trc_fifo.cpp
+++ b/apps/trc_fifo.cpp
@@ -1,8 +1,8 @@
-#include "tulips/system/Logger.h"
 #include <tulips/api/Client.h>
 #include <tulips/api/Defaults.h>
 #include <tulips/api/Server.h>
 #include <tulips/system/Compiler.h>
+#include <tulips/system/Logger.h>
 #include <tulips/transport/shm/Device.h>
 #include <csignal>
 #include <cstdio>

--- a/include/tulips/api/Client.h
+++ b/include/tulips/api/Client.h
@@ -47,9 +47,9 @@ public:
     return m_ethfrom.process(len, data, ts);
   }
 
-  inline Status sent(uint8_t* const data) override
+  inline Status sent(const uint16_t len, uint8_t* const data) override
   {
-    return m_ethfrom.sent(data);
+    return m_ethfrom.sent(len, data);
   }
 
   /**
@@ -138,7 +138,10 @@ private:
       return Status::Ok;
     }
 
-    Status sent(UNUSED uint8_t* const buf) override { return Status::Ok; }
+    Status sent(UNUSED const uint16_t len, UNUSED uint8_t* const buf) override
+    {
+      return Status::Ok;
+    }
   };
 #endif
 

--- a/include/tulips/api/Client.h
+++ b/include/tulips/api/Client.h
@@ -13,12 +13,13 @@
 #include <tulips/transport/Device.h>
 #include <list>
 #include <map>
+#include <optional>
 #include <vector>
 #include <unistd.h>
 
 namespace tulips::api {
 
-class Client
+class Client final
   : public interface::Client
   , public stack::tcpv4::EventHandler
 {
@@ -59,6 +60,10 @@ public:
   using interface::Client::open;
 
   Status open(const uint8_t options, ID& id) override;
+
+  Status setHostName(const ID id, std::string_view hn) override;
+
+  Status getHostName(const ID id, std::optional<std::string>& hn) override;
 
   Status connect(const ID id, stack::ipv4::Address const& ripaddr,
                  const stack::tcpv4::Port rport) override;
@@ -115,6 +120,7 @@ private:
     State state;
     stack::tcpv4::Connection::ID conn;
     uint8_t opts;
+    std::optional<std::string> hostname;
 #ifdef TULIPS_ENABLE_LATENCY_MONITOR
     size_t count;
     system::Clock::Value pre;

--- a/include/tulips/api/Client.h
+++ b/include/tulips/api/Client.h
@@ -47,6 +47,11 @@ public:
     return m_ethfrom.process(len, data, ts);
   }
 
+  inline Status sent(uint8_t* const data) override
+  {
+    return m_ethfrom.sent(data);
+  }
+
   /**
    * Client interface.
    */
@@ -132,6 +137,8 @@ private:
     {
       return Status::Ok;
     }
+
+    Status sent(UNUSED uint8_t* const buf) override { return Status::Ok; }
   };
 #endif
 

--- a/include/tulips/api/Interface.h
+++ b/include/tulips/api/Interface.h
@@ -7,6 +7,7 @@
 #include <tulips/system/Clock.h>
 #include <tulips/transport/Device.h>
 #include <cstdint>
+#include <optional>
 
 namespace tulips::api::interface {
 
@@ -144,6 +145,26 @@ public:
    * @return the status of the operation.
    */
   virtual Status open(const uint8_t options, ID& id) = 0;
+
+  /**
+   * Set the remote host name for a given connection.
+   *
+   * @param id the connection handle.
+   * @param hn the remote host name.
+   *
+   * @return the status of the operation.
+   */
+  virtual Status setHostName(const ID id, std::string_view hn) = 0;
+
+  /**
+   * Get the remote host name for a given connection.
+   *
+   * @param id the connection handle.
+   * @param hn the remote host name.
+   *
+   * @return the status of the operation.
+   */
+  virtual Status getHostName(const ID id, std::optional<std::string>& hn) = 0;
 
   /**
    * Connect a handle to a remote server using its IP and port.

--- a/include/tulips/api/Server.h
+++ b/include/tulips/api/Server.h
@@ -45,6 +45,11 @@ public:
     return m_ethfrom.process(len, data, ts);
   }
 
+  inline Status sent(uint8_t* const data) override
+  {
+    return m_ethfrom.sent(data);
+  }
+
   /**
    * Server interface.
    */
@@ -83,6 +88,8 @@ private:
     {
       return Status::Ok;
     }
+
+    Status sent(UNUSED uint8_t* const data) override { return Status::Ok; }
   };
 #endif
 

--- a/include/tulips/api/Server.h
+++ b/include/tulips/api/Server.h
@@ -45,9 +45,9 @@ public:
     return m_ethfrom.process(len, data, ts);
   }
 
-  inline Status sent(uint8_t* const data) override
+  inline Status sent(const uint16_t len, uint8_t* const data) override
   {
-    return m_ethfrom.sent(data);
+    return m_ethfrom.sent(len, data);
   }
 
   /**
@@ -89,7 +89,10 @@ private:
       return Status::Ok;
     }
 
-    Status sent(UNUSED uint8_t* const data) override { return Status::Ok; }
+    Status sent(UNUSED const uint16_t len, UNUSED uint8_t* const data) override
+    {
+      return Status::Ok;
+    }
   };
 #endif
 

--- a/include/tulips/fifo/fifo.h
+++ b/include/tulips/fifo/fifo.h
@@ -84,6 +84,12 @@ tulips_fifo_must_commit(tulips_fifo_t const fifo)
   return TULIPS_FIFO_NO;
 }
 
+USED static inline size_t
+tulips_fifo_length(tulips_fifo_t const fifo)
+{
+  return fifo->write_count - fifo->read_count;
+}
+
 USED static inline tulips_fifo_error_t
 tulips_fifo_front(tulips_fifo_t const fifo, void** const data)
 {

--- a/include/tulips/ssl/Client.h
+++ b/include/tulips/ssl/Client.h
@@ -7,7 +7,7 @@
 
 namespace tulips::ssl {
 
-class Client
+class Client final
   : public api::interface::Client
   , public api::interface::Client::Delegate
 {
@@ -52,6 +52,10 @@ public:
   using api::interface::Client::open;
 
   Status open(const uint8_t options, ID& id) override;
+
+  Status setHostName(const ID id, std::string_view hn) override;
+
+  Status getHostName(const ID id, std::optional<std::string>& hn) override;
 
   Status connect(const ID id, stack::ipv4::Address const& ripaddr,
                  const stack::tcpv4::Port rport) override;

--- a/include/tulips/ssl/Client.h
+++ b/include/tulips/ssl/Client.h
@@ -40,6 +40,11 @@ public:
     return m_client->process(len, data, ts);
   }
 
+  inline Status sent(uint8_t* const data) override
+  {
+    return m_client->sent(data);
+  }
+
   /**
    * Client interface.
    */

--- a/include/tulips/ssl/Client.h
+++ b/include/tulips/ssl/Client.h
@@ -40,9 +40,9 @@ public:
     return m_client->process(len, data, ts);
   }
 
-  inline Status sent(uint8_t* const data) override
+  inline Status sent(const uint16_t len, uint8_t* const data) override
   {
-    return m_client->sent(data);
+    return m_client->sent(len, data);
   }
 
   /**

--- a/include/tulips/ssl/Client.h
+++ b/include/tulips/ssl/Client.h
@@ -94,7 +94,6 @@ private:
 
   api::interface::Client::Delegate& m_delegate;
   system::Logger& m_log;
-  transport::Device& m_dev;
   std::unique_ptr<tulips::api::Client> m_client;
   void* m_context;
   bool m_savekeys;

--- a/include/tulips/ssl/Protocol.h
+++ b/include/tulips/ssl/Protocol.h
@@ -6,6 +6,7 @@ namespace tulips::ssl {
 
 enum class Protocol
 {
+  Auto,
   SSLv3,
   TLS,
 };

--- a/include/tulips/ssl/Server.h
+++ b/include/tulips/ssl/Server.h
@@ -36,6 +36,11 @@ public:
     return m_server->process(len, data, ts);
   }
 
+  inline Status sent(uint8_t* const data) override
+  {
+    return m_server->sent(data);
+  }
+
   /**
    * Server interface.
    */

--- a/include/tulips/ssl/Server.h
+++ b/include/tulips/ssl/Server.h
@@ -36,9 +36,9 @@ public:
     return m_server->process(len, data, ts);
   }
 
-  inline Status sent(uint8_t* const data) override
+  inline Status sent(const uint16_t len, uint8_t* const data) override
   {
-    return m_server->sent(data);
+    return m_server->sent(len, data);
   }
 
   /**

--- a/include/tulips/ssl/Server.h
+++ b/include/tulips/ssl/Server.h
@@ -99,7 +99,6 @@ private:
 
   api::interface::Server::Delegate& m_delegate;
   system::Logger& m_log;
-  transport::Device& m_dev;
   std::unique_ptr<api::Server> m_server;
   void* m_context;
 };

--- a/include/tulips/stack/arp/Processor.h
+++ b/include/tulips/stack/arp/Processor.h
@@ -20,7 +20,7 @@ public:
   Status run() override;
   Status process(const uint16_t len, const uint8_t* const data,
                  const Timestamp ts) override;
-  Status sent(uint8_t* const buf) override;
+  Status sent(const uint16_t len, uint8_t* const buf) override;
 
   bool has(ipv4::Address const& destipaddr);
   Status discover(ipv4::Address const& destipaddr);

--- a/include/tulips/stack/arp/Processor.h
+++ b/include/tulips/stack/arp/Processor.h
@@ -20,6 +20,7 @@ public:
   Status run() override;
   Status process(const uint16_t len, const uint8_t* const data,
                  const Timestamp ts) override;
+  Status sent(uint8_t* const buf) override;
 
   bool has(ipv4::Address const& destipaddr);
   Status discover(ipv4::Address const& destipaddr);

--- a/include/tulips/stack/ethernet/Processor.h
+++ b/include/tulips/stack/ethernet/Processor.h
@@ -27,7 +27,7 @@ public:
   Status run() override;
   Status process(const uint16_t len, const uint8_t* const data,
                  const Timestamp ts) override;
-  Status sent(uint8_t* const buf) override;
+  Status sent(const uint16_t len, uint8_t* const buf) override;
 
   Address const& sourceAddress() { return m_srceAddress; }
 

--- a/include/tulips/stack/ethernet/Processor.h
+++ b/include/tulips/stack/ethernet/Processor.h
@@ -27,6 +27,7 @@ public:
   Status run() override;
   Status process(const uint16_t len, const uint8_t* const data,
                  const Timestamp ts) override;
+  Status sent(uint8_t* const buf) override;
 
   Address const& sourceAddress() { return m_srceAddress; }
 

--- a/include/tulips/stack/ethernet/Producer.h
+++ b/include/tulips/stack/ethernet/Producer.h
@@ -18,7 +18,7 @@ public:
   uint32_t mss() const override { return m_prod.mss() - HEADER_LEN; }
 
   Status prepare(uint8_t*& buf) override;
-  Status commit(const uint32_t len, uint8_t* const buf,
+  Status commit(const uint16_t len, uint8_t* const buf,
                 const uint16_t mss = 0) override;
   Status release(uint8_t* const buf) override;
 

--- a/include/tulips/stack/ethernet/Producer.h
+++ b/include/tulips/stack/ethernet/Producer.h
@@ -20,6 +20,7 @@ public:
   Status prepare(uint8_t*& buf) override;
   Status commit(const uint32_t len, uint8_t* const buf,
                 const uint16_t mss = 0) override;
+  Status release(uint8_t* const buf) override;
 
   Address const& hostAddress() { return m_hostAddress; }
 

--- a/include/tulips/stack/icmpv4/Processor.h
+++ b/include/tulips/stack/icmpv4/Processor.h
@@ -20,7 +20,7 @@ public:
   Status run() override { return Status::Ok; }
   Status process(const uint16_t len, const uint8_t* const data,
                  const Timestamp ts) override;
-  Status sent(uint8_t* const buf) override;
+  Status sent(const uint16_t len, uint8_t* const buf) override;
 
   Request& attach(ethernet::Producer& eth, ipv4::Producer& ip4);
   void detach(Request& req);

--- a/include/tulips/stack/icmpv4/Processor.h
+++ b/include/tulips/stack/icmpv4/Processor.h
@@ -20,6 +20,7 @@ public:
   Status run() override { return Status::Ok; }
   Status process(const uint16_t len, const uint8_t* const data,
                  const Timestamp ts) override;
+  Status sent(uint8_t* const buf) override;
 
   Request& attach(ethernet::Producer& eth, ipv4::Producer& ip4);
   void detach(Request& req);

--- a/include/tulips/stack/ipv4/Processor.h
+++ b/include/tulips/stack/ipv4/Processor.h
@@ -40,7 +40,7 @@ public:
   Status run() override;
   Status process(const uint16_t len, const uint8_t* const data,
                  const Timestamp ts) override;
-  Status sent(uint8_t* const buf) override;
+  Status sent(const uint16_t len, uint8_t* const buf) override;
 
   Address const& sourceAddress() const { return m_srceAddress; }
 

--- a/include/tulips/stack/ipv4/Processor.h
+++ b/include/tulips/stack/ipv4/Processor.h
@@ -40,6 +40,7 @@ public:
   Status run() override;
   Status process(const uint16_t len, const uint8_t* const data,
                  const Timestamp ts) override;
+  Status sent(uint8_t* const buf) override;
 
   Address const& sourceAddress() const { return m_srceAddress; }
 

--- a/include/tulips/stack/ipv4/Producer.h
+++ b/include/tulips/stack/ipv4/Producer.h
@@ -22,7 +22,7 @@ public:
   uint32_t mss() const override { return m_eth.mss() - HEADER_LEN; }
 
   Status prepare(uint8_t*& buf) override;
-  Status commit(const uint32_t len, uint8_t* const buf,
+  Status commit(const uint16_t len, uint8_t* const buf,
                 const uint16_t mss = 0) override;
   Status release(uint8_t* const buf) override;
 

--- a/include/tulips/stack/ipv4/Producer.h
+++ b/include/tulips/stack/ipv4/Producer.h
@@ -24,6 +24,7 @@ public:
   Status prepare(uint8_t*& buf) override;
   Status commit(const uint32_t len, uint8_t* const buf,
                 const uint16_t mss = 0) override;
+  Status release(uint8_t* const buf) override;
 
   Address const& hostAddress() const { return m_hostAddress; }
 

--- a/include/tulips/stack/tcpv4/Processor.h
+++ b/include/tulips/stack/tcpv4/Processor.h
@@ -57,7 +57,7 @@ public:
   Status run() override;
   Status process(const uint16_t len, const uint8_t* const data,
                  const Timestamp ts) override;
-  Status sent(uint8_t* const data) override;
+  Status sent(const uint16_t len, uint8_t* const data) override;
 
   Processor& setEthernetProcessor(ethernet::Processor& eth)
   {

--- a/include/tulips/stack/tcpv4/Processor.h
+++ b/include/tulips/stack/tcpv4/Processor.h
@@ -57,6 +57,7 @@ public:
   Status run() override;
   Status process(const uint16_t len, const uint8_t* const data,
                  const Timestamp ts) override;
+  Status sent(uint8_t* const data) override;
 
   Processor& setEthernetProcessor(ethernet::Processor& eth)
   {

--- a/include/tulips/stack/tcpv4/Processor.h
+++ b/include/tulips/stack/tcpv4/Processor.h
@@ -131,6 +131,25 @@ private:
                            const uint16_t len, const uint8_t* const data);
 #endif
 
+  /**
+   * Close a connection.
+   *
+   * @param e the connection to close.
+   *
+   * @return the status of the operation.
+   */
+  void close(Connection& e);
+
+  /**
+   * Process the incoming packet for a given connection.
+   *
+   * @param e the connection.
+   * @param len the length of the packet.
+   * @param data the packet data.
+   * @param ts the timestamp of the event.
+   *
+   * @return the status of the operation.
+   */
   Status process(Connection& e, const uint16_t len, const uint8_t* const data,
                  const Timestamp ts);
 

--- a/include/tulips/stack/tcpv4/Segment.h
+++ b/include/tulips/stack/tcpv4/Segment.h
@@ -9,7 +9,7 @@ namespace tulips::stack::tcpv4 {
 class Segment
 {
 public:
-  Segment();
+  Segment() = default;
 
 private:
   inline void set(const uint32_t len, const uint32_t seq, uint8_t* const dat)

--- a/include/tulips/stack/tcpv4/Segment.h
+++ b/include/tulips/stack/tcpv4/Segment.h
@@ -28,12 +28,6 @@ private:
     m_dat = nullptr;
   }
 
-  inline void swap(uint8_t* const to)
-  {
-    memcpy(to, m_dat, m_len);
-    m_dat = to;
-  }
-
   /*
    * The len field is used to check if the segment was fully acknowledged. It
    * is also used to check if the segment is valid (=0).

--- a/include/tulips/transport/Processor.h
+++ b/include/tulips/transport/Processor.h
@@ -40,11 +40,12 @@ public:
   /**
    * Notify the processor that a buffer has been sent.
    *
-   * @param buf the buffer that has been sent.
+   * @param len the length of the piece of data.
+   * @param data the piece of data.
    *
    * @return the status of the operation.
    */
-  virtual Status sent(uint8_t* const buf) = 0;
+  virtual Status sent(const uint16_t len, uint8_t* const data) = 0;
 };
 
 }

--- a/include/tulips/transport/Processor.h
+++ b/include/tulips/transport/Processor.h
@@ -36,6 +36,15 @@ public:
    */
   virtual Status process(const uint16_t len, const uint8_t* const data,
                          const Timestamp ts) = 0;
+
+  /**
+   * Notify the processor that a buffer has been sent.
+   *
+   * @param buf the buffer that has been sent.
+   *
+   * @return the status of the operation.
+   */
+  virtual Status sent(uint8_t* const buf) = 0;
 };
 
 }

--- a/include/tulips/transport/Producer.h
+++ b/include/tulips/transport/Producer.h
@@ -36,6 +36,15 @@ public:
    */
   virtual Status commit(const uint32_t len, uint8_t* const buf,
                         const uint16_t mss = 0) = 0;
+
+  /**
+   * Release a prepared buffer.
+   *
+   * @param buf a reference to the buffer to release.
+   *
+   * @return the status of the operation.
+   */
+  virtual Status release(uint8_t* const buf) = 0;
 };
 
 }

--- a/include/tulips/transport/Producer.h
+++ b/include/tulips/transport/Producer.h
@@ -34,7 +34,7 @@ public:
    *
    * @return the status of the operation.
    */
-  virtual Status commit(const uint32_t len, uint8_t* const buf,
+  virtual Status commit(const uint16_t len, uint8_t* const buf,
                         const uint16_t mss = 0) = 0;
 
   /**

--- a/include/tulips/transport/check/Device.h
+++ b/include/tulips/transport/check/Device.h
@@ -65,7 +65,7 @@ public:
   }
 
   Status prepare(uint8_t*& buf) override;
-  Status commit(const uint32_t len, uint8_t* const buf,
+  Status commit(const uint16_t len, uint8_t* const buf,
                 const uint16_t mss = 0) override;
   Status release(uint8_t* const buf) override;
 

--- a/include/tulips/transport/check/Device.h
+++ b/include/tulips/transport/check/Device.h
@@ -73,7 +73,7 @@ private:
   Status run() override { return Status::Ok; }
   Status process(const uint16_t len, const uint8_t* const data,
                  const Timestamp ts) override;
-  Status sent(uint8_t* const buf) override;
+  Status sent(const uint16_t len, uint8_t* const buf) override;
 
   static bool check(const uint8_t* const data, const size_t len);
 

--- a/include/tulips/transport/check/Device.h
+++ b/include/tulips/transport/check/Device.h
@@ -67,11 +67,13 @@ public:
   Status prepare(uint8_t*& buf) override;
   Status commit(const uint32_t len, uint8_t* const buf,
                 const uint16_t mss = 0) override;
+  Status release(uint8_t* const buf) override;
 
 private:
   Status run() override { return Status::Ok; }
   Status process(const uint16_t len, const uint8_t* const data,
                  const Timestamp ts) override;
+  Status sent(uint8_t* const buf) override;
 
   static bool check(const uint8_t* const data, const size_t len);
 

--- a/include/tulips/transport/ena/Device.h
+++ b/include/tulips/transport/ena/Device.h
@@ -41,7 +41,7 @@ public:
   Status wait(Processor& proc, const uint64_t ns) override;
 
   Status prepare(uint8_t*& buf) override;
-  Status commit(const uint32_t len, uint8_t* const buf,
+  Status commit(const uint16_t len, uint8_t* const buf,
                 const uint16_t mss) override;
   Status release(uint8_t* const buf) override;
 

--- a/include/tulips/transport/ena/Device.h
+++ b/include/tulips/transport/ena/Device.h
@@ -54,6 +54,8 @@ public:
   uint16_t receiveBuffersAvailable() const override { return m_nbuf; }
 
 private:
+  using SentBuffer = std::tuple<uint16_t, uint8_t*>;
+
   Device(system::Logger& log, const uint16_t port_id, const uint16_t queue_id,
          const size_t nbuf, const size_t htsz, const size_t hlen,
          const uint8_t* const hkey, stack::ethernet::Address const& m_address,

--- a/include/tulips/transport/ena/Device.h
+++ b/include/tulips/transport/ena/Device.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <tulips/fifo/fifo.h>
 #include <tulips/stack/Ethernet.h>
 #include <tulips/stack/IPv4.h>
 #include <tulips/system/CircularBuffer.h>
@@ -72,6 +73,7 @@ private:
   struct rte_eth_rss_reta_entry64* m_reta;
   system::CircularBuffer::Ref m_buffer;
   uint8_t* m_packet;
+  tulips_fifo_t m_sent;
 
   friend class Port;
 

--- a/include/tulips/transport/ena/Device.h
+++ b/include/tulips/transport/ena/Device.h
@@ -42,6 +42,7 @@ public:
   Status prepare(uint8_t*& buf) override;
   Status commit(const uint32_t len, uint8_t* const buf,
                 const uint16_t mss) override;
+  Status release(uint8_t* const buf) override;
 
   uint32_t mtu() const override { return m_mtu - stack::ethernet::HEADER_LEN; }
 

--- a/include/tulips/transport/ena/Device.h
+++ b/include/tulips/transport/ena/Device.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <tulips/fifo/fifo.h>
 #include <tulips/stack/Ethernet.h>
 #include <tulips/stack/IPv4.h>
 #include <tulips/system/CircularBuffer.h>
@@ -11,6 +10,7 @@
 #include <cstdlib>
 #include <limits>
 #include <string>
+#include <vector>
 #include <dpdk/rte_ethdev.h>
 #include <dpdk/rte_mempool.h>
 
@@ -75,7 +75,8 @@ private:
   struct rte_eth_rss_reta_entry64* m_reta;
   system::CircularBuffer::Ref m_buffer;
   uint8_t* m_packet;
-  tulips_fifo_t m_sent;
+  std::vector<struct rte_mbuf*> m_free;
+  std::vector<SentBuffer> m_sent;
 
   friend class Port;
 

--- a/include/tulips/transport/ena/Device.h
+++ b/include/tulips/transport/ena/Device.h
@@ -65,6 +65,8 @@ private:
 
   system::CircularBuffer::Ref internalBuffer() { return m_buffer; }
 
+  Status clearSentBuffers(Processor& proc);
+
   uint16_t m_portid;
   uint16_t m_queueid;
   size_t m_nbuf;

--- a/include/tulips/transport/ena/RawProcessor.h
+++ b/include/tulips/transport/ena/RawProcessor.h
@@ -1,4 +1,5 @@
 #include <tulips/system/CircularBuffer.h>
+#include <tulips/system/Compiler.h>
 #include <tulips/system/SpinLock.h>
 #include <tulips/transport/Processor.h>
 #include <vector>
@@ -11,6 +12,7 @@ public:
   Status run() override { return Status::Ok; }
   Status process(const uint16_t len, const uint8_t* const data,
                  const Timestamp ts) override;
+  Status sent(UNUSED uint8_t* const data) override;
 
   void add(system::CircularBuffer::Ref const& buffer);
 

--- a/include/tulips/transport/ena/RawProcessor.h
+++ b/include/tulips/transport/ena/RawProcessor.h
@@ -12,7 +12,7 @@ public:
   Status run() override { return Status::Ok; }
   Status process(const uint16_t len, const uint8_t* const data,
                  const Timestamp ts) override;
-  Status sent(UNUSED uint8_t* const data) override;
+  Status sent(UNUSED const uint16_t len, UNUSED uint8_t* const data) override;
 
   void add(system::CircularBuffer::Ref const& buffer);
 

--- a/include/tulips/transport/erase/Device.h
+++ b/include/tulips/transport/erase/Device.h
@@ -60,7 +60,7 @@ public:
   }
 
   Status prepare(uint8_t*& buf) override;
-  Status commit(const uint32_t len, uint8_t* const buf,
+  Status commit(const uint16_t len, uint8_t* const buf,
                 const uint16_t mss = 0) override;
   Status release(uint8_t* const buf) override;
 

--- a/include/tulips/transport/erase/Device.h
+++ b/include/tulips/transport/erase/Device.h
@@ -62,6 +62,7 @@ public:
   Status prepare(uint8_t*& buf) override;
   Status commit(const uint32_t len, uint8_t* const buf,
                 const uint16_t mss = 0) override;
+  Status release(uint8_t* const buf) override;
 
 private:
   transport::Device& m_device;

--- a/include/tulips/transport/list/Device.h
+++ b/include/tulips/transport/list/Device.h
@@ -6,6 +6,7 @@
 #include <tulips/system/Logger.h>
 #include <tulips/transport/Device.h>
 #include <cstdlib>
+#include <cstring>
 #include <limits>
 #include <list>
 #include <new>
@@ -22,11 +23,23 @@ public:
     static Packet* allocate(const uint32_t mtu)
     {
       void* data = malloc(sizeof(Packet) + mtu);
-      return new (data) Packet;
+      return new (data) Packet(mtu);
     }
 
-    static void release(Packet* p) { free(p); }
+    static void release(Packet* packet) { free(packet); }
 
+    Packet() = delete;
+    Packet(const uint32_t mtu) : mtu(mtu), len(0), data() {}
+
+    Packet* clone() const
+    {
+      auto* c = allocate(mtu);
+      memcpy(c->data, data, len);
+      c->len = len;
+      return c;
+    }
+
+    uint32_t mtu;
     uint32_t len;
     uint8_t data[];
   } PACKED;
@@ -95,6 +108,7 @@ protected:
   uint32_t m_mtu;
   List& m_read;
   List& m_write;
+  List m_sent;
   pthread_mutex_t m_mutex;
   pthread_cond_t m_cond;
 };

--- a/include/tulips/transport/list/Device.h
+++ b/include/tulips/transport/list/Device.h
@@ -78,7 +78,7 @@ public:
   Status wait(Processor& proc, const uint64_t ns) override;
 
   Status prepare(uint8_t*& buf) override;
-  Status commit(const uint32_t len, uint8_t* const buf,
+  Status commit(const uint16_t len, uint8_t* const buf,
                 const uint16_t mss) override;
   Status release(uint8_t* const buf) override;
 

--- a/include/tulips/transport/list/Device.h
+++ b/include/tulips/transport/list/Device.h
@@ -67,6 +67,7 @@ public:
   Status prepare(uint8_t*& buf) override;
   Status commit(const uint32_t len, uint8_t* const buf,
                 const uint16_t mss) override;
+  Status release(uint8_t* const buf) override;
 
   uint32_t mtu() const override { return m_mtu - stack::ethernet::HEADER_LEN; }
 

--- a/include/tulips/transport/npipe/Device.h
+++ b/include/tulips/transport/npipe/Device.h
@@ -39,7 +39,7 @@ public:
   {}
 
   Status prepare(uint8_t*& buf) override;
-  Status commit(const uint32_t len, uint8_t* const buf,
+  Status commit(const uint16_t len, uint8_t* const buf,
                 const uint16_t mss = 0) override;
   Status release(uint8_t* const buf) override;
 

--- a/include/tulips/transport/npipe/Device.h
+++ b/include/tulips/transport/npipe/Device.h
@@ -64,7 +64,7 @@ protected:
   {
     ssize_t ret = 0;
     for (uint32_t s = 0; s < len; s += (uint32_t)ret) {
-      ret = ::write(write_fd, buf + s, len - s);
+      ret = ::write(m_wrfd, buf + s, len - s);
       if (ret < 0) {
         return false;
       }
@@ -80,8 +80,9 @@ protected:
   stack::ipv4::Address m_nm;
   uint8_t m_read_buffer[BUFLEN];
   uint8_t m_write_buffer[BUFLEN];
-  int read_fd;
-  int write_fd;
+  int m_rdfd;
+  int m_wrfd;
+  uint16_t m_sent;
 };
 
 class ClientDevice : public Device

--- a/include/tulips/transport/npipe/Device.h
+++ b/include/tulips/transport/npipe/Device.h
@@ -41,6 +41,7 @@ public:
   Status prepare(uint8_t*& buf) override;
   Status commit(const uint32_t len, uint8_t* const buf,
                 const uint16_t mss = 0) override;
+  Status release(uint8_t* const buf) override;
 
   Status poll(Processor& proc) override;
   Status wait(Processor& proc, const uint64_t ns) override;

--- a/include/tulips/transport/ofed/Device.h
+++ b/include/tulips/transport/ofed/Device.h
@@ -61,6 +61,7 @@ public:
 
 private:
   using Filters = std::map<uint16_t, ibv_flow*>;
+  using SentBuffer = std::tuple<uint16_t, uint8_t*>;
 
   void construct(std::string_view ifn, const uint16_t nbuf);
   Status postReceive(const uint16_t id);

--- a/include/tulips/transport/ofed/Device.h
+++ b/include/tulips/transport/ofed/Device.h
@@ -57,6 +57,7 @@ public:
   Status prepare(uint8_t*& buf) override;
   Status commit(const uint32_t len, uint8_t* const buf,
                 const uint16_t mss = 0) override;
+  Status release(uint8_t* const buf) override;
 
 private:
   using Filters = std::map<uint16_t, ibv_flow*>;
@@ -85,7 +86,8 @@ private:
   uint8_t* m_recvbuf;
   ibv_mr* m_sendmr;
   ibv_mr* m_recvmr;
-  tulips_fifo_t m_fifo;
+  tulips_fifo_t m_free;
+  tulips_fifo_t m_sent;
   ibv_flow* m_bcast;
   ibv_flow* m_flow;
   Filters m_filters;

--- a/include/tulips/transport/ofed/Device.h
+++ b/include/tulips/transport/ofed/Device.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <tulips/fifo/fifo.h>
 #include <tulips/stack/Ethernet.h>
 #include <tulips/stack/IPv4.h>
 #include <tulips/transport/Device.h>
 #include <cstdint>
 #include <map>
 #include <string>
+#include <vector>
 #include <infiniband/verbs.h>
 
 namespace tulips::transport::ofed {
@@ -87,8 +87,8 @@ private:
   uint8_t* m_recvbuf;
   ibv_mr* m_sendmr;
   ibv_mr* m_recvmr;
-  tulips_fifo_t m_free;
-  tulips_fifo_t m_sent;
+  std::vector<uint8_t*> m_free;
+  std::vector<SentBuffer> m_sent;
   ibv_flow* m_bcast;
   ibv_flow* m_flow;
   Filters m_filters;

--- a/include/tulips/transport/ofed/Device.h
+++ b/include/tulips/transport/ofed/Device.h
@@ -55,7 +55,7 @@ public:
   uint32_t mss() const override { return m_buflen; }
 
   Status prepare(uint8_t*& buf) override;
-  Status commit(const uint32_t len, uint8_t* const buf,
+  Status commit(const uint16_t len, uint8_t* const buf,
                 const uint16_t mss = 0) override;
   Status release(uint8_t* const buf) override;
 

--- a/include/tulips/transport/pcap/Device.h
+++ b/include/tulips/transport/pcap/Device.h
@@ -70,7 +70,7 @@ public:
   }
 
   Status prepare(uint8_t*& buf) override;
-  Status commit(const uint32_t len, uint8_t* const buf,
+  Status commit(const uint16_t len, uint8_t* const buf,
                 const uint16_t mss = 0) override;
   Status release(uint8_t* const buf) override;
 

--- a/include/tulips/transport/pcap/Device.h
+++ b/include/tulips/transport/pcap/Device.h
@@ -72,6 +72,7 @@ public:
   Status prepare(uint8_t*& buf) override;
   Status commit(const uint32_t len, uint8_t* const buf,
                 const uint16_t mss = 0) override;
+  Status release(uint8_t* const buf) override;
 
 private:
   Status run() override { return Status::Ok; }

--- a/include/tulips/transport/pcap/Device.h
+++ b/include/tulips/transport/pcap/Device.h
@@ -78,6 +78,7 @@ private:
   Status run() override { return Status::Ok; }
   Status process(const uint16_t len, const uint8_t* const data,
                  const Timestamp ts) override;
+  Status sent(uint8_t* const data) override;
 
   transport::Device& m_device;
   pcap_t* m_pcap;

--- a/include/tulips/transport/pcap/Device.h
+++ b/include/tulips/transport/pcap/Device.h
@@ -78,7 +78,7 @@ private:
   Status run() override { return Status::Ok; }
   Status process(const uint16_t len, const uint8_t* const data,
                  const Timestamp ts) override;
-  Status sent(uint8_t* const data) override;
+  Status sent(const uint16_t len, uint8_t* const data) override;
 
   transport::Device& m_device;
   pcap_t* m_pcap;

--- a/include/tulips/transport/shm/Device.h
+++ b/include/tulips/transport/shm/Device.h
@@ -47,7 +47,7 @@ public:
   Status wait(Processor& proc, const uint64_t ns) override;
 
   Status prepare(uint8_t*& buf) override;
-  Status commit(const uint32_t len, uint8_t* const buf,
+  Status commit(const uint16_t len, uint8_t* const buf,
                 const uint16_t mss = 0) override;
   Status release(uint8_t* const buf) override;
 

--- a/include/tulips/transport/shm/Device.h
+++ b/include/tulips/transport/shm/Device.h
@@ -53,25 +53,22 @@ public:
 
   uint32_t mtu() const override
   {
-    return write_fifo->data_len - sizeof(Packet) - stack::ethernet::HEADER_LEN;
+    return m_write->data_len - sizeof(Packet) - stack::ethernet::HEADER_LEN;
   }
 
-  uint32_t mss() const override
-  {
-    return write_fifo->data_len - sizeof(Packet);
-  }
+  uint32_t mss() const override { return m_write->data_len - sizeof(Packet); }
 
   uint8_t receiveBufferLengthLog2() const override
   {
-    return system::utils::log2(write_fifo->data_len);
+    return system::utils::log2(m_write->data_len);
   }
 
   uint16_t receiveBuffersAvailable() const override
   {
-    if (tulips_fifo_empty(write_fifo) == TULIPS_FIFO_YES) {
-      return write_fifo->depth;
+    if (tulips_fifo_empty(m_write) == TULIPS_FIFO_YES) {
+      return m_write->depth;
     } else {
-      uint64_t delta = write_fifo->read_count - write_fifo->write_count;
+      uint64_t delta = m_write->read_count - m_write->write_count;
       if (delta > std::numeric_limits<uint16_t>::max()) {
         return std::numeric_limits<uint16_t>::max();
       }
@@ -95,8 +92,9 @@ protected:
   stack::ipv4::Address m_ip;
   stack::ipv4::Address m_dr;
   stack::ipv4::Address m_nm;
-  tulips_fifo_t read_fifo;
-  tulips_fifo_t write_fifo;
+  tulips_fifo_t m_read;
+  tulips_fifo_t m_write;
+  tulips_fifo_t m_sent;
   pthread_mutex_t m_mutex;
   pthread_cond_t m_cond;
 };

--- a/include/tulips/transport/shm/Device.h
+++ b/include/tulips/transport/shm/Device.h
@@ -49,6 +49,7 @@ public:
   Status prepare(uint8_t*& buf) override;
   Status commit(const uint32_t len, uint8_t* const buf,
                 const uint16_t mss = 0) override;
+  Status release(uint8_t* const buf) override;
 
   uint32_t mtu() const override
   {

--- a/src/ssl/BIO.cpp
+++ b/src/ssl/BIO.cpp
@@ -73,8 +73,6 @@ s_ctrl(BIO* h, int cmd, long num, UNUSED void* ptr)
       BIO_set_shutdown(h, (int)num);
       break;
     case BIO_CTRL_WPENDING:
-      ret = 0L;
-      break;
     case BIO_CTRL_PENDING:
       ret = (long)b->read_available();
       break;

--- a/src/ssl/Client.cpp
+++ b/src/ssl/Client.cpp
@@ -31,7 +31,6 @@ Client::Client(system::Logger& log, api::interface::Client::Delegate& delegate,
                const size_t nconn, const bool save_keys)
   : m_delegate(delegate)
   , m_log(log)
-  , m_dev(device)
   , m_client(std::make_unique<api::Client>(log, *this, device, nconn))
   , m_context(nullptr)
   , m_savekeys(save_keys)
@@ -354,7 +353,7 @@ Client::onConnected(ID const& id, void* const cookie, const Timestamp ts)
    * Create the context.
    */
   auto* ssl = AS_SSL(m_context);
-  auto* c = new Context(ssl, m_log, m_dev.mss(), id, cookie, ts, keyfd);
+  auto* c = new Context(ssl, m_log, id, cookie, ts, keyfd);
   c->state = Context::State::Connect;
   return c;
 }

--- a/src/ssl/Client.cpp
+++ b/src/ssl/Client.cpp
@@ -434,22 +434,10 @@ Client::onNewData(ID const& id, void* const cookie, const uint8_t* const data,
    * Grab the context.
    */
   Context& c = *reinterpret_cast<Context*>(cookie);
-  auto pre = c.state;
   /*
    * Write the data in the input BIO.
    */
-  auto res = c.onNewData(id, m_delegate, data, len, ts, alen, sdata, slen);
-  auto post = c.state;
-  /*
-   * Check for the ready state transition.
-   */
-  if (pre == Context::State::Connect && post == Context::State::Ready) {
-    c.cookie = m_delegate.onConnected(c.id, c.cookie, ts);
-  }
-  /*
-   * Done.
-   */
-  return res;
+  return c.onNewData(id, m_delegate, data, len, ts, alen, sdata, slen);
 }
 
 void
@@ -472,7 +460,7 @@ Client::flush(const ID id, void* const cookie)
   /*
    * Check if there is any pending data.
    */
-  size_t len = c.pending();
+  size_t len = c.pendingRead();
   if (len == 0) {
     return Status::Ok;
   }

--- a/src/ssl/Context.cpp
+++ b/src/ssl/Context.cpp
@@ -1,4 +1,5 @@
 #include "Context.h"
+#include "tulips/ssl/Protocol.h"
 #include <fcntl.h>
 #include <openssl/err.h>
 
@@ -16,6 +17,10 @@ getMethod(const Protocol type, const bool server, long& flags)
    * Check requested type.
    */
   switch (type) {
+    case Protocol::Auto: {
+      method = server ? TLS_server_method() : TLS_client_method();
+      flags = SSL_OP_NO_SSLv2 | SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1;
+    }
     case Protocol::SSLv3: {
       method = server ? SSLv23_server_method() : SSLv23_client_method();
       flags = SSL_OP_NO_SSLv2 | SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1 |

--- a/src/ssl/Context.cpp
+++ b/src/ssl/Context.cpp
@@ -163,14 +163,18 @@ Context::flush(uint32_t alen, uint8_t* const sdata, uint32_t& slen)
   /*
    * Check and send any data in the BIO buffer.
    */
-  size_t len = pending();
+  size_t len = pendingRead();
   if (len == 0) {
     return Action::Continue;
   }
   /*
-   * Send the response.
+   * Get how much data to send back.
    */
   size_t rlen = len > alen ? alen : len;
+  log.trace("SSL", "flushing ", rlen, "B (", len, "/", alen, ")");
+  /*
+   * Send the response.
+   */
   BIO_read(bout, sdata, (int)rlen);
   slen = rlen;
   return Action::Continue;

--- a/src/ssl/Context.cpp
+++ b/src/ssl/Context.cpp
@@ -68,21 +68,20 @@ errorToString(const int err)
  * SSL context.
  */
 
-Context::Context(SSL_CTX* ctx, system::Logger& log, const size_t buflen,
+Context::Context(SSL_CTX* ctx, system::Logger& log,
                  const api::interface::Client::ID id, void* cookie,
                  const system::Clock::Value ts, const int keyfd)
   : log(log)
-  , buflen(buflen)
   , id(id)
   , cookie(cookie)
   , ts(ts)
   , keyfd(keyfd)
-  , bin(bio::allocate(buflen))
-  , bout(bio::allocate(buflen))
+  , bin(bio::allocate(BUFLEN))
+  , bout(bio::allocate(BUFLEN))
   , ssl(SSL_new(ctx))
   , state(State::Closed)
   , blocked(false)
-  , rdbf(new uint8_t[buflen])
+  , rdbf(new uint8_t[BUFLEN])
 {
   SSL_set_bio(ssl, bin, bout);
   SSL_set_app_data(ssl, this);

--- a/src/ssl/Context.h
+++ b/src/ssl/Context.h
@@ -58,7 +58,7 @@ struct Context
     /*
      * If the BIO has data pending, flush it.
      */
-    if (pending() > 0) {
+    if (pendingRead() > 0) {
       return flush(alen, sdata, slen);
     }
     /*
@@ -113,7 +113,7 @@ struct Context
     /*
      * Show the buffer level.
      */
-    auto acc = BIO_pending(bin);
+    auto acc = pendingWrite();
     log.trace("SSL", "new data: ", len, "B, (", acc, "/", BUFLEN, ")");
     /*
      * Only accept Ready state.
@@ -126,9 +126,9 @@ struct Context
      * Process the internal buffer as long as there is data available.
      */
     do {
-      auto bl0 = BIO_pending(bin);
+      auto bl0 = pendingWrite();
       ret = SSL_read(ssl, rdbf, BUFLEN);
-      auto bl1 = BIO_pending(bin);
+      auto bl1 = pendingWrite();
       log.trace("SSL", "SSL_read: ", ret, " (", bl0, " -> ", bl1, ")");
       /*
        * Handle error conditions.
@@ -172,7 +172,7 @@ struct Context
          */
         else {
           auto m = errorToString(err);
-          auto b = BIO_pending(bin);
+          auto b = pendingWrite();
           log.error("SSL", "SSL_read error: ", m, " (", ret, ", ", err, ", ",
                     sht, ") ", b, "B");
           return Action::Abort;
@@ -212,7 +212,7 @@ struct Context
     /*
      * Show the buffer level.
      */
-    auto avl = BIO_pending(bin);
+    auto avl = pendingWrite();
     log.trace("SSL", "new data: ", len, "B, (", avl, "/", BUFLEN, ")");
     /*
      * Check the connection's state.
@@ -290,9 +290,9 @@ struct Context
          * Process the internal buffer as long as there is data available.
          */
         do {
-          auto bl0 = BIO_pending(bin);
+          auto bl0 = pendingWrite();
           ret = SSL_read(ssl, rdbf, BUFLEN);
-          auto bl1 = BIO_pending(bin);
+          auto bl1 = pendingWrite();
           log.trace("SSL", "SSL_read: ", ret, " (", bl0, " -> ", bl1, ")");
           /*
            * Handle error conditions.
@@ -336,7 +336,7 @@ struct Context
              */
             else {
               auto m = errorToString(err);
-              auto b = BIO_pending(bin);
+              auto b = pendingWrite();
               log.error("SSL", "SSL_read error: ", m, " (", ret, ", ", err,
                         ", ", sht, ") ", b, "B");
               return Action::Abort;
@@ -403,7 +403,12 @@ struct Context
   /**
    * Return how much data is pending on the read channel.
    */
-  inline size_t pending() { return BIO_pending(bout); }
+  inline size_t pendingRead() { return BIO_pending(bout); }
+
+  /**
+   * Return how much data is pending on the write channel.
+   */
+  inline size_t pendingWrite() { return BIO_pending(bin); }
 
   /**
    * Handle delegate response.

--- a/src/ssl/Protocol.cpp
+++ b/src/ssl/Protocol.cpp
@@ -6,6 +6,8 @@ std::string
 toString(const Protocol type)
 {
   switch (type) {
+    case Protocol::Auto:
+      return "Auto";
     case Protocol::SSLv3:
       return "SSLv3";
     case Protocol::TLS:

--- a/src/ssl/Server.cpp
+++ b/src/ssl/Server.cpp
@@ -10,7 +10,6 @@ Server::Server(system::Logger& log, api::interface::Server::Delegate& delegate,
                std::string_view cert, std::string_view key, const size_t nconn)
   : m_delegate(delegate)
   , m_log(log)
-  , m_dev(device)
   , m_server(std::make_unique<api::Server>(log, *this, device, nconn))
   , m_context(nullptr)
 {
@@ -168,7 +167,7 @@ void*
 Server::onConnected(ID const& id, void* const cookie, const Timestamp ts)
 {
   auto* ssl = AS_SSL(m_context);
-  auto* c = new Context(ssl, m_log, m_dev.mss(), id, cookie, ts, -1);
+  auto* c = new Context(ssl, m_log, id, cookie, ts, -1);
   c->state = Context::State::Accept;
   return c;
 }

--- a/src/ssl/Server.cpp
+++ b/src/ssl/Server.cpp
@@ -168,7 +168,7 @@ Server::onConnected(ID const& id, void* const cookie, const Timestamp ts)
 {
   auto* ssl = AS_SSL(m_context);
   auto* c = new Context(ssl, m_log, id, cookie, ts, -1);
-  c->state = Context::State::Accept;
+  c->state = Context::State::Accepting;
   return c;
 }
 
@@ -236,8 +236,11 @@ Server::onNewData(ID const& id, void* const cookie, const uint8_t* const data,
   auto post = c.state;
   /*
    * Check for the ready state transition.
+   *
+   * FIXME(xrg): we will run into issues here if the delegate sends data while
+   * at the same time the SSL context needs to flush back data.
    */
-  if (pre == Context::State::Accept && post == Context::State::Ready) {
+  if (pre == Context::State::Accepting && post == Context::State::Ready) {
     c.cookie = m_delegate.onConnected(c.id, c.cookie, ts);
   }
   /*

--- a/src/ssl/Server.cpp
+++ b/src/ssl/Server.cpp
@@ -264,7 +264,7 @@ Server::flush(const ID id, void* const cookie)
   /*
    * Send the pending data.
    */
-  size_t len = c.pending();
+  size_t len = c.pendingRead();
   if (len == 0) {
     return Status::Ok;
   }

--- a/src/stack/Utils.cpp
+++ b/src/stack/Utils.cpp
@@ -1,7 +1,7 @@
-#include "tulips/stack/Utils.h"
 #include <tulips/stack/Ethernet.h>
 #include <tulips/stack/IPv4.h>
 #include <tulips/stack/TCPv4.h>
+#include <tulips/stack/Utils.h>
 #include <cstdint>
 #include <cstring>
 #include <iomanip>

--- a/src/stack/arp/Processor.cpp
+++ b/src/stack/arp/Processor.cpp
@@ -139,7 +139,7 @@ Processor::process(const uint16_t len, const uint8_t* const data,
 Status
 Processor::sent(UNUSED const uint16_t len, uint8_t* const buf)
 {
-  return m_ipv4.release(buf);
+  return m_eth.release(buf);
 }
 
 bool

--- a/src/stack/arp/Processor.cpp
+++ b/src/stack/arp/Processor.cpp
@@ -137,7 +137,7 @@ Processor::process(const uint16_t len, const uint8_t* const data,
 }
 
 Status
-Processor::sent(uint8_t* const buf)
+Processor::sent(UNUSED const uint16_t len, uint8_t* const buf)
 {
   return m_ipv4.release(buf);
 }

--- a/src/stack/arp/Processor.cpp
+++ b/src/stack/arp/Processor.cpp
@@ -136,6 +136,12 @@ Processor::process(const uint16_t len, const uint8_t* const data,
   return Status::Ok;
 }
 
+Status
+Processor::sent(uint8_t* const buf)
+{
+  return m_ipv4.release(buf);
+}
+
 bool
 Processor::has(ipv4::Address const& destipaddr)
 {

--- a/src/stack/ethernet/Processor.cpp
+++ b/src/stack/ethernet/Processor.cpp
@@ -115,7 +115,7 @@ Processor::process(const uint16_t len, const uint8_t* const data,
 }
 
 Status
-Processor::sent(uint8_t* const buf)
+Processor::sent(const uint16_t len, uint8_t* const buf)
 {
   const auto* hdr = reinterpret_cast<const Header*>(buf);
   /*
@@ -128,16 +128,16 @@ Processor::sent(uint8_t* const buf)
   switch (m_type) {
 #ifdef TULIPS_ENABLE_ARP
     case ETHTYPE_ARP: {
-      return m_arp->sent(buf + HEADER_LEN);
+      return m_arp->sent(len - HEADER_LEN, buf + HEADER_LEN);
     }
 #endif
     case ETHTYPE_IP: {
-      return m_ipv4->sent(buf + HEADER_LEN);
+      return m_ipv4->sent(len - HEADER_LEN, buf + HEADER_LEN);
     }
     default: {
 #ifdef TULIPS_ENABLE_RAW
       if (m_type <= 1500) {
-        return m_raw->sent(buf + HEADER_LEN);
+        return m_raw->sent(len - HEADER_LEN, buf + HEADER_LEN);
       }
 #endif
       break;

--- a/src/stack/ethernet/Processor.cpp
+++ b/src/stack/ethernet/Processor.cpp
@@ -58,14 +58,14 @@ Processor::process(const uint16_t len, const uint8_t* const data,
 {
   m_log.trace("ETH", "processing frame: ", len, "B");
   /*
-   * Grab the incoming information
+   * Grab the incoming information.
    */
   const auto* hdr = reinterpret_cast<const Header*>(data);
   m_srceAddress = hdr->src;
   m_destAddress = hdr->dest;
   m_type = ntohs(hdr->type);
   /*
-   * Process the remaing buffer
+   * Process the remaing buffer.
    */
   Status ret;
   switch (m_type) {
@@ -112,6 +112,41 @@ Processor::process(const uint16_t len, const uint8_t* const data,
    * Process outputs
    */
   return ret;
+}
+
+Status
+Processor::sent(uint8_t* const buf)
+{
+  const auto* hdr = reinterpret_cast<const Header*>(buf);
+  /*
+   * Grab the type.
+   */
+  m_type = ntohs(hdr->type);
+  /*
+   * Forward depending on the type.
+   */
+  switch (m_type) {
+#ifdef TULIPS_ENABLE_ARP
+    case ETHTYPE_ARP: {
+      return m_arp->sent(buf + HEADER_LEN);
+    }
+#endif
+    case ETHTYPE_IP: {
+      return m_ipv4->sent(buf + HEADER_LEN);
+    }
+    default: {
+#ifdef TULIPS_ENABLE_RAW
+      if (m_type <= 1500) {
+        return m_raw->sent(buf + HEADER_LEN);
+      }
+#endif
+      break;
+    }
+  }
+  /*
+   * Done.
+   */
+  return Status::UnsupportedProtocol;
 }
 
 }

--- a/src/stack/ethernet/Producer.cpp
+++ b/src/stack/ethernet/Producer.cpp
@@ -35,7 +35,7 @@ Producer::prepare(uint8_t*& buf)
 }
 
 Status
-Producer::commit(const uint32_t len, uint8_t* const buf, const uint16_t mss)
+Producer::commit(const uint16_t len, uint8_t* const buf, const uint16_t mss)
 {
   m_log.trace("ETH", "committing frame: ", len, "B");
   return m_prod.commit(len + HEADER_LEN, buf - HEADER_LEN, mss);

--- a/src/stack/ethernet/Producer.cpp
+++ b/src/stack/ethernet/Producer.cpp
@@ -40,4 +40,10 @@ Producer::commit(const uint32_t len, uint8_t* const buf, const uint16_t mss)
   return m_prod.commit(len + HEADER_LEN, buf - HEADER_LEN, mss);
 }
 
+Status
+Producer::release(uint8_t* const buf)
+{
+  return m_prod.release(buf);
+}
+
 }

--- a/src/stack/ethernet/Producer.cpp
+++ b/src/stack/ethernet/Producer.cpp
@@ -1,4 +1,4 @@
-#include "tulips/stack/Ethernet.h"
+#include <tulips/stack/Ethernet.h>
 #include <tulips/stack/ethernet/Producer.h>
 #include <arpa/inet.h>
 

--- a/src/stack/ethernet/Producer.cpp
+++ b/src/stack/ethernet/Producer.cpp
@@ -1,3 +1,4 @@
+#include "tulips/stack/Ethernet.h"
 #include <tulips/stack/ethernet/Producer.h>
 #include <arpa/inet.h>
 
@@ -43,7 +44,7 @@ Producer::commit(const uint32_t len, uint8_t* const buf, const uint16_t mss)
 Status
 Producer::release(uint8_t* const buf)
 {
-  return m_prod.release(buf);
+  return m_prod.release(buf - HEADER_LEN);
 }
 
 }

--- a/src/stack/icmpv4/Processor.cpp
+++ b/src/stack/icmpv4/Processor.cpp
@@ -116,7 +116,7 @@ Processor::process(const uint16_t len, const uint8_t* const data,
 }
 
 Status
-Processor::sent(uint8_t* const buf)
+Processor::sent(UNUSED const uint16_t len, uint8_t* const buf)
 {
   return m_ip4out.release(buf);
 }

--- a/src/stack/icmpv4/Processor.cpp
+++ b/src/stack/icmpv4/Processor.cpp
@@ -115,4 +115,10 @@ Processor::process(const uint16_t len, const uint8_t* const data,
   return m_ip4out.commit(len, outdata);
 }
 
+Status
+Processor::sent(uint8_t* const buf)
+{
+  return m_ip4out.release(buf);
+}
+
 }

--- a/src/stack/ipv4/Processor.cpp
+++ b/src/stack/ipv4/Processor.cpp
@@ -157,24 +157,25 @@ Processor::process(UNUSED const uint16_t len, const uint8_t* const data,
 }
 
 Status
-Processor::sent(uint8_t* const data)
+Processor::sent(UNUSED const uint16_t len, uint8_t* const data)
 {
+  auto iplen = ntohs(INIP->len) - HEADER_LEN;
   auto proto = INIP->proto;
   /*
    * Call the processors
    */
   switch (Protocol(proto)) {
     case Protocol::TCP: {
-      return m_tcp->sent(data + HEADER_LEN);
+      return m_tcp->sent(iplen, data + HEADER_LEN);
     }
 #ifdef TULIPS_ENABLE_ICMP
     case Protocol::ICMP: {
-      return m_icmp->sent(data + HEADER_LEN);
+      return m_icmp->sent(iplen, data + HEADER_LEN);
     }
 #endif
 #ifdef TULIPS_ENABLE_RAW
     case Protocol::TEST: {
-      return m_raw->sent(data + HEADER_LEN);
+      return m_raw->sent(iplen, data + HEADER_LEN);
     }
 #endif
     default: {

--- a/src/stack/ipv4/Processor.cpp
+++ b/src/stack/ipv4/Processor.cpp
@@ -156,4 +156,35 @@ Processor::process(UNUSED const uint16_t len, const uint8_t* const data,
   return ret;
 }
 
+Status
+Processor::sent(uint8_t* const data)
+{
+  auto proto = INIP->proto;
+  /*
+   * Call the processors
+   */
+  switch (Protocol(proto)) {
+    case Protocol::TCP: {
+      return m_tcp->sent(data + HEADER_LEN);
+    }
+#ifdef TULIPS_ENABLE_ICMP
+    case Protocol::ICMP: {
+      return m_icmp->sent(data + HEADER_LEN);
+    }
+#endif
+#ifdef TULIPS_ENABLE_RAW
+    case Protocol::TEST: {
+      return m_raw->sent(data + HEADER_LEN);
+    }
+#endif
+    default: {
+      break;
+    }
+  }
+  /*
+   * Done.
+   */
+  return Status::UnsupportedProtocol;
+}
+
 }

--- a/src/stack/ipv4/Producer.cpp
+++ b/src/stack/ipv4/Producer.cpp
@@ -65,10 +65,10 @@ Producer::prepare(uint8_t*& buf)
 }
 
 Status
-Producer::commit(const uint32_t len, uint8_t* const buf, const uint16_t mss)
+Producer::commit(const uint16_t len, uint8_t* const buf, const uint16_t mss)
 {
   uint8_t* outdata = buf - HEADER_LEN;
-  uint32_t outlen = len + HEADER_LEN;
+  uint16_t outlen = len + HEADER_LEN;
   /*
    * Fill in the remaining header fields.
    */

--- a/src/stack/ipv4/Producer.cpp
+++ b/src/stack/ipv4/Producer.cpp
@@ -77,6 +77,7 @@ Producer::commit(const uint16_t len, uint8_t* const buf, const uint16_t mss)
    * Compute the checksum
    */
 #ifndef TULIPS_HAS_HW_CHECKSUM
+  OUTIP->ipchksum = 0;
   OUTIP->ipchksum = ~checksum(outdata);
 #endif
   /*

--- a/src/stack/ipv4/Producer.cpp
+++ b/src/stack/ipv4/Producer.cpp
@@ -90,7 +90,7 @@ Producer::commit(const uint32_t len, uint8_t* const buf, const uint16_t mss)
 Status
 Producer::release(uint8_t* const buf)
 {
-  return m_eth.release(buf);
+  return m_eth.release(buf - HEADER_LEN);
 }
 
 }

--- a/src/stack/ipv4/Producer.cpp
+++ b/src/stack/ipv4/Producer.cpp
@@ -87,4 +87,10 @@ Producer::commit(const uint32_t len, uint8_t* const buf, const uint16_t mss)
   return m_eth.commit(outlen, outdata, mss);
 }
 
+Status
+Producer::release(uint8_t* const buf)
+{
+  return m_eth.release(buf);
+}
+
 }

--- a/src/stack/tcpv4/Client.cpp
+++ b/src/stack/tcpv4/Client.cpp
@@ -299,6 +299,7 @@ Processor::send(Connection::ID const& id, const uint32_t len,
    * Send immediately if Nagle's algorithm has been disabled.
    */
   if (HAS_NODELAY(c)) {
+    m_log.trace("TCP", "sending ", slen, "B from client");
     return sendNoDelay(c, off == len ? Flag::PSH : 0);
   }
   /*

--- a/src/stack/tcpv4/Client.cpp
+++ b/src/stack/tcpv4/Client.cpp
@@ -106,6 +106,7 @@ Processor::connect(ethernet::Address const& rhwaddr,
    * Bail out if there is no free connection available.
    */
   if (e == m_conns.end()) {
+    m_ipv4to.release(outdata);
     return Status::NoMoreResources;
   }
   /*
@@ -114,6 +115,7 @@ Processor::connect(ethernet::Address const& rhwaddr,
   ret = m_device.listen(ipv4::Protocol::TCP, lport, ripaddr, rport);
   if (ret != Status::Ok) {
     m_log.error("TCP4", "registering client-side filter failed");
+    m_ipv4to.release(outdata);
     return ret;
   }
   /*
@@ -144,6 +146,10 @@ Processor::connect(ethernet::Address const& rhwaddr,
   e->m_timer = RTO;
   e->m_cookie = nullptr;
   /*
+   * Update the connection index.
+   */
+  m_index.insert({ std::hash<Connection>()(*e), e->id() });
+  /*
    * Prepare the SYN. SYN segments don't contain any data but have a size of 1
    * to increase the sequence number by 1.
    */
@@ -154,14 +160,9 @@ Processor::connect(ethernet::Address const& rhwaddr,
    * Send SYN.
    */
   if (sendSyn(*e, seg) != Status::Ok) {
-    m_device.unlisten(ipv4::Protocol::TCP, lport, ripaddr, rport);
-    e->m_state = Connection::CLOSED;
+    close(*e);
     return ret;
   }
-  /*
-   * Update the connection index.
-   */
-  m_index.insert({ std::hash<Connection>()(*e), e->id() });
   /*
    * Done.
    */
@@ -172,6 +173,7 @@ Processor::connect(ethernet::Address const& rhwaddr,
 Status
 Processor::abort(Connection::ID const& id)
 {
+  m_log.debug("TCP4", "Abort connection ", id, " requested");
   /*
    * Check if the connection is valid.
    */
@@ -180,12 +182,8 @@ Processor::abort(Connection::ID const& id)
   }
   Connection& c = m_conns[id];
   /*
-   * Abort the connection
+   * Notify the handler and return.
    */
-  m_device.unlisten(ipv4::Protocol::TCP, c.m_lport, c.m_ripaddr, c.m_rport);
-  m_index.erase(std::hash<Connection>()(c));
-  c.m_state = Connection::CLOSED;
-  m_log.debug("TCP4", "Abort connection ", id, " requested");
   m_handler.onAborted(c, system::Clock::read());
   /*
    * Send the RST message.

--- a/src/stack/tcpv4/Client.cpp
+++ b/src/stack/tcpv4/Client.cpp
@@ -1,5 +1,5 @@
 #include "Debug.h"
-#include "tulips/stack/IPv4.h"
+#include <tulips/stack/IPv4.h>
 #include <tulips/stack/Utils.h>
 #include <tulips/stack/tcpv4/Options.h>
 #include <tulips/stack/tcpv4/Processor.h>

--- a/src/stack/tcpv4/Client.cpp
+++ b/src/stack/tcpv4/Client.cpp
@@ -144,7 +144,8 @@ Processor::connect(ethernet::Address const& rhwaddr,
   e->m_timer = RTO;
   e->m_cookie = nullptr;
   /*
-   * Prepare the SYN. The length of SYN is 1.
+   * Prepare the SYN. SYN segments don't contain any data but have a size of 1
+   * to increase the sequence number by 1.
    */
   Segment& seg = e->nextAvailableSegment();
   seg.set(1, e->m_snd_nxt, outdata);

--- a/src/stack/tcpv4/Processor.cpp
+++ b/src/stack/tcpv4/Processor.cpp
@@ -294,6 +294,7 @@ Processor::process(const uint16_t len, const uint8_t* const data,
 Status
 Processor::sent(const uint16_t len, uint8_t* const data)
 {
+  m_log.trace("TCP4", "buffer ", (void*)data, " len ", len, " sent");
   /*
    * Packets with no data have no segments, so we can release them.
    */

--- a/src/stack/tcpv4/Processor.cpp
+++ b/src/stack/tcpv4/Processor.cpp
@@ -290,6 +290,12 @@ Processor::process(const uint16_t len, const uint8_t* const data,
   return sendSynAck(*e, seg);
 }
 
+Status
+Processor::sent(uint8_t* const data)
+{
+  return m_ipv4to.release(data);
+}
+
 #if !(defined(TULIPS_HAS_HW_CHECKSUM) && defined(TULIPS_DISABLE_CHECKSUM_CHECK))
 uint16_t
 Processor::checksum(ipv4::Address const& src, ipv4::Address const& dst,
@@ -979,5 +985,4 @@ Processor::process(Connection& e, const uint16_t len, const uint8_t* const data,
    */
   return Status::Ok;
 }
-
 }

--- a/src/stack/tcpv4/Processor.cpp
+++ b/src/stack/tcpv4/Processor.cpp
@@ -847,6 +847,7 @@ Processor::process(Connection& e, const uint16_t len, const uint8_t* const data,
             if (rlen > alen) {
               rlen = alen;
             }
+            m_log.trace("TCP", "queueing ", rlen, "B from onNewData()");
             e.m_slen += rlen;
           }
           /*

--- a/src/stack/tcpv4/Processor.cpp
+++ b/src/stack/tcpv4/Processor.cpp
@@ -1,6 +1,6 @@
 #include "Debug.h"
-#include "tulips/stack/TCPv4.h"
 #include <tulips/stack/IPv4.h>
+#include <tulips/stack/TCPv4.h>
 #include <tulips/stack/Utils.h>
 #include <tulips/stack/tcpv4/Options.h>
 #include <tulips/stack/tcpv4/Processor.h>

--- a/src/stack/tcpv4/Segment.cpp
+++ b/src/stack/tcpv4/Segment.cpp
@@ -1,7 +1,0 @@
-#include <tulips/stack/tcpv4/Segment.h>
-
-namespace tulips::stack::tcpv4 {
-
-Segment::Segment() : m_len(0), m_seq(0), m_dat(nullptr) {}
-
-}

--- a/src/stack/tcpv4/Send.cpp
+++ b/src/stack/tcpv4/Send.cpp
@@ -360,9 +360,9 @@ Processor::send(Connection& e, const uint32_t len, Segment& s)
   /*
    * Print the flow information.
    */
-  m_log.trace("FLOW", (rexmit ? "<+ " : "<- "), getFlags(*OUTTCP),
-              " len:", s.m_len, " seq:", s.m_seq, " ack:", e.m_rcv_nxt,
-              " seg:", e.id(s), " lvl:", e.freeSegments());
+  m_log.trace("FLOW", (rexmit ? "<+ " : "<- "), getFlags(*OUTTCP), " len:", len,
+              " seq:", s.m_seq, " ack:", e.m_rcv_nxt, " seg:", e.id(s),
+              " lvl:", e.freeSegments());
   /*
    * Update the connection and segment state.
    */

--- a/src/stack/tcpv4/Send.cpp
+++ b/src/stack/tcpv4/Send.cpp
@@ -155,6 +155,7 @@ Processor::sendAck(Connection& e)
   if (unlikely(e.hasPendingSendData())) {
     memcpy(bdat, e.m_sdat, e.m_slen);
     blen = e.m_slen;
+    e.m_slen = 0;
   }
   /*
    * Prepare the frame for an ACK.

--- a/src/transport/check/Device.cpp
+++ b/src/transport/check/Device.cpp
@@ -50,7 +50,7 @@ Device::prepare(uint8_t*& buf)
 }
 
 Status
-Device::commit(const uint32_t len, uint8_t* const buf, const uint16_t mss)
+Device::commit(const uint16_t len, uint8_t* const buf, const uint16_t mss)
 {
   if (!check(m_buffer, len)) {
     throw std::runtime_error("Empty packet has been received !");

--- a/src/transport/check/Device.cpp
+++ b/src/transport/check/Device.cpp
@@ -36,6 +36,12 @@ Device::process(const uint16_t len, const uint8_t* const data,
 }
 
 Status
+Device::sent(uint8_t* const buf)
+{
+  return m_proc->sent(buf);
+}
+
+Status
 Device::prepare(uint8_t*& buf)
 {
   Status ret = m_device.prepare(buf);
@@ -50,6 +56,12 @@ Device::commit(const uint32_t len, uint8_t* const buf, const uint16_t mss)
     throw std::runtime_error("Empty packet has been received !");
   }
   return m_device.commit(len, buf, mss);
+}
+
+Status
+Device::release(uint8_t* const buf)
+{
+  return m_device.release(buf);
 }
 
 bool

--- a/src/transport/check/Device.cpp
+++ b/src/transport/check/Device.cpp
@@ -36,9 +36,9 @@ Device::process(const uint16_t len, const uint8_t* const data,
 }
 
 Status
-Device::sent(uint8_t* const buf)
+Device::sent(const uint16_t len, uint8_t* const buf)
 {
-  return m_proc->sent(buf);
+  return m_proc->sent(len, buf);
 }
 
 Status

--- a/src/transport/ena/CMakeLists.txt
+++ b/src/transport/ena/CMakeLists.txt
@@ -6,7 +6,12 @@ include_directories(${LibDPDK_INCLUDE_DIRS})
 file(GLOB SOURCES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.cpp *.h)
 
 add_library(tulips_transport_ena SHARED ${SOURCES})
-target_link_libraries(tulips_transport_ena PUBLIC tulips_stack ${LibDPDK_LINK_LIBRARIES})
+target_link_libraries(tulips_transport_ena
+  PRIVATE
+  tulips_fifo
+  tulips_stack
+  PUBLIC
+  ${LibDPDK_LINK_LIBRARIES})
 
 add_library(tulips_transport_ena_static STATIC ${SOURCES})
 

--- a/src/transport/ena/CMakeLists.txt
+++ b/src/transport/ena/CMakeLists.txt
@@ -8,7 +8,6 @@ file(GLOB SOURCES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.cpp *.h)
 add_library(tulips_transport_ena SHARED ${SOURCES})
 target_link_libraries(tulips_transport_ena
   PRIVATE
-  tulips_fifo
   tulips_stack
   PUBLIC
   ${LibDPDK_LINK_LIBRARIES})

--- a/src/transport/ena/Device.cpp
+++ b/src/transport/ena/Device.cpp
@@ -306,7 +306,7 @@ Device::prepare(uint8_t*& buf)
 }
 
 Status
-Device::commit(const uint32_t len, uint8_t* const buf,
+Device::commit(const uint16_t len, uint8_t* const buf,
                UNUSED const uint16_t mss)
 {
   uint16_t res = 0;

--- a/src/transport/ena/Device.cpp
+++ b/src/transport/ena/Device.cpp
@@ -380,6 +380,7 @@ Device::commit(const uint16_t len, uint8_t* const buf,
 Status
 Device::release(uint8_t* const buf)
 {
+  m_log.trace("ENA", "releasing buffer ", (void*)buf);
   auto* mbuf = *reinterpret_cast<struct rte_mbuf**>(buf - 8);
   rte_pktmbuf_free(mbuf);
   return Status::Ok;

--- a/src/transport/ena/Device.cpp
+++ b/src/transport/ena/Device.cpp
@@ -1,4 +1,3 @@
-#include "tulips/fifo/fifo.h"
 #include <tulips/stack/IPv4.h>
 #include <tulips/stack/Utils.h>
 #include <tulips/system/CircularBuffer.h>
@@ -11,6 +10,7 @@
 #include <cstdlib>
 #include <ctime>
 #include <sstream>
+#include <stdexcept>
 #include <thread>
 #include <dpdk/rte_config.h>
 #include <dpdk/rte_dev.h>
@@ -44,7 +44,8 @@ Device::Device(system::Logger& log, const uint16_t port_id,
   , m_reta(new struct rte_eth_rss_reta_entry64[htsz >> 6])
   , m_buffer(system::CircularBuffer::allocate(16384))
   , m_packet(new uint8_t[16384])
-  , m_sent(TULIPS_FIFO_DEFAULT_VALUE)
+  , m_free()
+  , m_sent()
   , m_address(address)
   , m_ip(ip)
   , m_dr(dr)
@@ -52,9 +53,20 @@ Device::Device(system::Logger& log, const uint16_t port_id,
   , m_mtu(mtu)
 {
   /*
-   * Create the sent FIFOs.
+   * Reserve space in the sent queue .
    */
-  tulips_fifo_create(m_nbuf, sizeof(SentBuffer), &m_sent);
+  m_free.reserve(nbuf);
+  m_sent.reserve(nbuf);
+  /*
+   * Populate the free buffer list.
+   */
+  for (size_t i = 0; i < nbuf; i += 1) {
+    auto* mbuf = rte_pktmbuf_alloc(m_txpool);
+    if (mbuf == nullptr) {
+      throw std::runtime_error("send buffer allocation failed");
+    }
+    m_free.push_back(mbuf);
+  }
   /*
    * Print some device information.
    */
@@ -69,9 +81,31 @@ Device::Device(system::Logger& log, const uint16_t port_id,
 
 Device::~Device()
 {
-  tulips_fifo_destroy(&m_sent);
+  /*
+   * Clean-up the unreleased send buffers.
+   */
+  while (!m_sent.empty()) {
+    auto info = m_sent.back();
+    m_sent.pop_back();
+    auto* mbuf = *reinterpret_cast<struct rte_mbuf**>(std::get<1>(info) - 8);
+    rte_pktmbuf_free(mbuf);
+  }
+  /*
+   * Clean-up the free send buffers.
+   */
+  while (!m_free.empty()) {
+    auto mbuf = m_free.back();
+    m_free.pop_back();
+    rte_pktmbuf_free(mbuf);
+  }
+  /*
+   * Delete the RETA.
+   */
   delete[] m_reta;
   m_reta = nullptr;
+  /*
+   * Delete the packet buffer.
+   */
   delete[] m_packet;
   m_packet = nullptr;
 }
@@ -170,24 +204,16 @@ Device::poll(Processor& proc)
   /*
    * Process the sent buffers.
    */
-  while (tulips_fifo_empty(m_sent) == TULIPS_FIFO_NO) {
-    SentBuffer* info;
+  while (!m_sent.empty()) {
     /*
-     * Get the front of the FIFO..
+     * Remove the last item (constant time).
      */
-    if (tulips_fifo_front(m_sent, (void**)&info) != TULIPS_FIFO_OK) {
-      return Status::HardwareError;
-    }
-    /*
-     * Pop the FIFO.
-     */
-    if (tulips_fifo_pop(m_sent) != TULIPS_FIFO_OK) {
-      return Status::HardwareError;
-    }
+    auto& info = m_sent.back();
+    m_sent.pop_back();
     /*
      * Notify the processor.
      */
-    auto ret = proc.sent(std::get<0>(*info), std::get<1>(*info));
+    auto ret = proc.sent(std::get<0>(info), std::get<1>(info));
     if (ret != Status::Ok) {
       return ret;
     }
@@ -279,17 +305,21 @@ Status
 Device::prepare(uint8_t*& buf)
 {
   /*
-   * Allocate a new buffer in the TX pool.
+   * Make sure we have free TX buffers.
    */
-  auto* mbuf = rte_pktmbuf_alloc(m_txpool);
-  if (mbuf == nullptr) {
+  if (m_free.empty()) {
     return Status::NoMoreResources;
   }
+  /*
+   * Get a new TX buffer.
+   */
+  auto mbuf = m_free.back();
+  m_free.pop_back();
   /*
    * Grab the data region.
    */
   buf = rte_pktmbuf_mtod(mbuf, uint8_t*);
-  m_log.trace("ENA", "preparing buffer ", (void*)buf);
+  m_log.trace("ENA", "preparing buffer ", (void*)buf, " ", (void*)mbuf);
   /*
    * Update the private data with the mbuf address.
    */
@@ -309,6 +339,8 @@ Device::commit(const uint16_t len, uint8_t* const buf,
    * Grab the packet buffer.
    */
   auto* mbuf = *reinterpret_cast<struct rte_mbuf**>(buf - 8);
+  m_log.trace("ENA", "committing buffer ", (void*)buf, " len ", len, " ",
+              (void*)mbuf);
   /*
    * Update the packet buffer length.
    */
@@ -360,12 +392,10 @@ Device::commit(const uint16_t len, uint8_t* const buf,
     m_log.error("ENA", "sending packet failed: ", error);
     return Status::HardwareError;
   }
-  m_log.trace("ENA", "committing buffer ", (void*)buf, " len ", len);
   /*
-   * Free the buffer.
+   * Queue the buffer.
    */
-  auto info = SentBuffer(len, buf);
-  tulips_fifo_push(m_sent, &buf);
+  m_sent.emplace_back(len, buf);
   /*
    * Done.
    */
@@ -375,9 +405,9 @@ Device::commit(const uint16_t len, uint8_t* const buf,
 Status
 Device::release(uint8_t* const buf)
 {
-  m_log.trace("ENA", "releasing buffer ", (void*)buf);
   auto* mbuf = *reinterpret_cast<struct rte_mbuf**>(buf - 8);
-  rte_pktmbuf_free(mbuf);
+  m_log.trace("ENA", "releasing buffer ", (void*)buf, " ", (void*)mbuf);
+  m_free.push_back(mbuf);
   return Status::Ok;
 }
 

--- a/src/transport/ena/Device.cpp
+++ b/src/transport/ena/Device.cpp
@@ -191,11 +191,6 @@ Device::poll(Processor& proc)
     if (ret != Status::Ok) {
       return ret;
     }
-    /*
-     * Return the buffer to the pool.
-     */
-    auto* mbuf = *reinterpret_cast<struct rte_mbuf**>(std::get<1>(*info) - 8);
-    rte_pktmbuf_free(mbuf);
   }
   /*
    * Process the internal buffer.

--- a/src/transport/ena/Device.cpp
+++ b/src/transport/ena/Device.cpp
@@ -336,4 +336,12 @@ Device::commit(const uint32_t len, uint8_t* const buf,
   return Status::Ok;
 }
 
+Status
+Device::release(uint8_t* const buf)
+{
+  auto* mbuf = *reinterpret_cast<struct rte_mbuf**>(buf - 8);
+  rte_pktmbuf_free(mbuf);
+  return Status::Ok;
+}
+
 }

--- a/src/transport/ena/RawProcessor.cpp
+++ b/src/transport/ena/RawProcessor.cpp
@@ -28,6 +28,12 @@ RawProcessor::process(const uint16_t len, const uint8_t* const data,
   return Status::Ok;
 }
 
+Status
+RawProcessor::sent(UNUSED uint8_t* const data)
+{
+  return Status::Ok;
+}
+
 void
 RawProcessor::add(system::CircularBuffer::Ref const& buffer)
 {

--- a/src/transport/ena/RawProcessor.cpp
+++ b/src/transport/ena/RawProcessor.cpp
@@ -29,7 +29,7 @@ RawProcessor::process(const uint16_t len, const uint8_t* const data,
 }
 
 Status
-RawProcessor::sent(UNUSED uint8_t* const data)
+RawProcessor::sent(UNUSED const uint16_t len, UNUSED uint8_t* const data)
 {
   return Status::Ok;
 }

--- a/src/transport/erase/Device.cpp
+++ b/src/transport/erase/Device.cpp
@@ -36,4 +36,10 @@ Device::commit(const uint32_t len, uint8_t* const buf, const uint16_t mss)
   return m_device.commit(len, buf, mss);
 }
 
+Status
+Device::release(uint8_t* const buf)
+{
+  return m_device.release(buf);
+}
+
 }

--- a/src/transport/erase/Device.cpp
+++ b/src/transport/erase/Device.cpp
@@ -31,7 +31,7 @@ Device::prepare(uint8_t*& buf)
 }
 
 Status
-Device::commit(const uint32_t len, uint8_t* const buf, const uint16_t mss)
+Device::commit(const uint16_t len, uint8_t* const buf, const uint16_t mss)
 {
   return m_device.commit(len, buf, mss);
 }

--- a/src/transport/list/Device.cpp
+++ b/src/transport/list/Device.cpp
@@ -115,6 +115,7 @@ Device::commit(const uint16_t len, uint8_t* const buf,
 Status
 Device::release(UNUSED uint8_t* const buf)
 {
+  m_log.trace("LIST", "releasing buffer ", (void*)buf);
   auto* packet = (Packet*)(buf - sizeof(Packet));
   m_sent.remove(packet);
   Packet::release(packet);

--- a/src/transport/list/Device.cpp
+++ b/src/transport/list/Device.cpp
@@ -31,23 +31,6 @@ Device::Device(system::Logger& log, stack::ethernet::Address const& address,
 
 Device::~Device()
 {
-  /*
-   * Deallocate any sent packets.
-   */
-  for (auto p : m_sent) {
-    Packet::release(p);
-  }
-  m_sent.clear();
-  /*
-   * Deallocate any uncommitted packets.
-   */
-  for (auto p : m_packets) {
-    Packet::release(p);
-  }
-  m_packets.clear();
-  /*
-   * Clear resources.
-   */
   pthread_cond_destroy(&m_cond);
   pthread_mutex_destroy(&m_mutex);
 }

--- a/src/transport/list/Device.cpp
+++ b/src/transport/list/Device.cpp
@@ -103,6 +103,15 @@ Device::commit(const uint32_t len, uint8_t* const buf,
 }
 
 Status
+Device::release(UNUSED uint8_t* const buf)
+{
+  /*
+   * NOTE(xrg): the LIST device does not support out-of-order buffer release.
+   */
+  return Status::Ok;
+}
+
+Status
 Device::drop()
 {
   if (m_read.empty()) {

--- a/src/transport/list/Device.cpp
+++ b/src/transport/list/Device.cpp
@@ -99,7 +99,7 @@ Device::prepare(uint8_t*& buf)
 }
 
 Status
-Device::commit(const uint32_t len, uint8_t* const buf,
+Device::commit(const uint16_t len, uint8_t* const buf,
                UNUSED const uint16_t mss)
 {
   auto* packet = (Packet*)(buf - sizeof(Packet));

--- a/src/transport/npipe/Device.cpp
+++ b/src/transport/npipe/Device.cpp
@@ -71,6 +71,15 @@ Device::commit(const uint32_t len, uint8_t* const buf,
 }
 
 Status
+Device::release(UNUSED uint8_t* const buf)
+{
+  /*
+   * NOTE(xrg): the NPIPE device does not support out-of-order buffer release.
+   */
+  return Status::Ok;
+}
+
+Status
 Device::poll(Processor& proc)
 {
   ssize_t ret = 0;

--- a/src/transport/npipe/Device.cpp
+++ b/src/transport/npipe/Device.cpp
@@ -46,7 +46,7 @@ Device::prepare(uint8_t*& buf)
 }
 
 Status
-Device::commit(const uint32_t len, uint8_t* const buf,
+Device::commit(const uint16_t len, uint8_t* const buf,
                UNUSED const uint16_t mss)
 {
   /*

--- a/src/transport/npipe/Device.cpp
+++ b/src/transport/npipe/Device.cpp
@@ -26,8 +26,9 @@ Device::Device(system::Logger& log, stack::ethernet::Address const& address,
   , m_nm(nm)
   , m_read_buffer()
   , m_write_buffer()
-  , read_fd(-1)
-  , write_fd(-1)
+  , m_rdfd(-1)
+  , m_wrfd(-1)
+  , m_sent(0)
 {
   memset(m_read_buffer, 0, BUFLEN);
   memset(m_write_buffer, 0, BUFLEN);
@@ -67,12 +68,14 @@ Device::commit(const uint16_t len, uint8_t* const buf,
    * Success.
    */
   m_log.debug("NPIPE", "commit ", len, "B");
+  m_sent = true;
   return Status::Ok;
 }
 
 Status
 Device::release(UNUSED uint8_t* const buf)
 {
+  m_log.trace("NPIPE", "releasing buffer ", (void*)buf);
   /*
    * NOTE(xrg): the NPIPE device does not support out-of-order buffer release.
    */
@@ -85,9 +88,19 @@ Device::poll(Processor& proc)
   ssize_t ret = 0;
   uint32_t len = 0;
   /*
+   * Check if any data was sent.
+   */
+  if (m_sent > 0) {
+    auto ret = proc.sent(m_sent, m_write_buffer);
+    if (ret != Status::Ok) {
+      return ret;
+    }
+    m_sent = 0;
+  }
+  /*
    * Read length first.
    */
-  ret = ::read(read_fd, &len, sizeof(len));
+  ret = ::read(m_rdfd, &len, sizeof(len));
   if (ret < 0) {
     if (errno == EAGAIN) {
       return Status::NoDataAvailable;
@@ -103,7 +116,7 @@ Device::poll(Processor& proc)
    * Now read the payload.
    */
   do {
-    ret = ::read(read_fd, m_read_buffer, len);
+    ret = ::read(m_rdfd, m_read_buffer, len);
     if (ret == 0 || (ret < 0 && errno != EAGAIN)) {
       m_log.error("NPIPE", "read error: ", strerror(errno));
       return Status::HardwareLinkLost;
@@ -133,9 +146,9 @@ Device::waitForInput(const uint64_t ns)
 
   fd_set fdset;
   FD_ZERO(&fdset);
-  FD_SET(read_fd, &fdset);
+  FD_SET(m_rdfd, &fdset);
 
-  return ::select(read_fd + 1, &fdset, nullptr, nullptr, &tv);
+  return ::select(m_rdfd + 1, &fdset, nullptr, nullptr, &tv);
 }
 
 /*
@@ -159,16 +172,16 @@ ClientDevice::ClientDevice(system::Logger& log,
    * Open the FIFOs.
    */
   auto rp = std::string(rf);
-  read_fd = open(rp.c_str(), O_RDONLY);
-  if (read_fd < 0) {
+  m_rdfd = open(rp.c_str(), O_RDONLY);
+  if (m_rdfd < 0) {
     throw std::runtime_error(strerror(errno));
   }
-  if (fcntl(read_fd, F_SETFL, O_NONBLOCK)) {
+  if (fcntl(m_rdfd, F_SETFL, O_NONBLOCK)) {
     throw std::runtime_error(strerror(errno));
   }
   auto wp = std::string(wf);
-  write_fd = open(wp.c_str(), O_WRONLY);
-  if (write_fd < 0) {
+  m_wrfd = open(wp.c_str(), O_WRONLY);
+  if (m_wrfd < 0) {
     throw std::runtime_error(strerror(errno));
   }
 }
@@ -210,16 +223,16 @@ ServerDevice::ServerDevice(system::Logger& log,
   /*
    * Open the FIFOs
    */
-  write_fd = open(m_wf.c_str(), O_WRONLY);
-  if (write_fd < 0) {
+  m_wrfd = open(m_wf.c_str(), O_WRONLY);
+  if (m_wrfd < 0) {
     throw std::runtime_error(strerror(errno));
   }
   sleep(1);
-  read_fd = open(m_rf.c_str(), O_RDONLY);
-  if (read_fd < 0) {
+  m_rdfd = open(m_rf.c_str(), O_RDONLY);
+  if (m_rdfd < 0) {
     throw std::runtime_error(strerror(errno));
   }
-  if (fcntl(read_fd, F_SETFL, O_NONBLOCK)) {
+  if (fcntl(m_rdfd, F_SETFL, O_NONBLOCK)) {
     throw std::runtime_error(strerror(errno));
   }
 }

--- a/src/transport/ofed/CMakeLists.txt
+++ b/src/transport/ofed/CMakeLists.txt
@@ -8,7 +8,6 @@ file(GLOB SOURCES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.cpp *.h)
 add_library(tulips_transport_ofed SHARED ${SOURCES} Utils.cpp Utils.h)
 target_link_libraries(tulips_transport_ofed
   PRIVATE
-  tulips_fifo
   tulips_stack
   tulips_transport_stubs
   PUBLIC

--- a/src/transport/ofed/Device.cpp
+++ b/src/transport/ofed/Device.cpp
@@ -797,6 +797,7 @@ Device::commit(const uint16_t len, uint8_t* const buf,
 Status
 Device::release(uint8_t* const buf)
 {
+  m_log.trace("OFED", "releasing buffer ", (void*)buf);
   tulips_fifo_push(m_free, &buf);
   return Status::Ok;
 }

--- a/src/transport/ofed/Device.cpp
+++ b/src/transport/ofed/Device.cpp
@@ -1,6 +1,4 @@
 #include "Utils.h"
-#include "tulips/fifo/fifo.h"
-#include <tulips/fifo/errors.h>
 #include <tulips/stack/Ethernet.h>
 #include <tulips/stack/IPv4.h>
 #include <tulips/stack/Utils.h>

--- a/src/transport/ofed/Device.cpp
+++ b/src/transport/ofed/Device.cpp
@@ -709,7 +709,7 @@ Device::prepare(uint8_t*& buf)
 }
 
 Status
-Device::commit(const uint32_t len, uint8_t* const buf,
+Device::commit(const uint16_t len, uint8_t* const buf,
                UNUSED const uint16_t mss)
 {
   /*

--- a/src/transport/pcap/Device.cpp
+++ b/src/transport/pcap/Device.cpp
@@ -103,4 +103,10 @@ Device::process(const uint16_t len, const uint8_t* const data,
   return m_proc->process(len, data, ts);
 }
 
+Status
+Device::sent(uint8_t* const data)
+{
+  return m_proc->sent(data);
+}
+
 }

--- a/src/transport/pcap/Device.cpp
+++ b/src/transport/pcap/Device.cpp
@@ -78,7 +78,7 @@ Device::prepare(uint8_t*& buf)
 }
 
 Status
-Device::commit(const uint32_t len, uint8_t* const buf, const uint16_t mss)
+Device::commit(const uint16_t len, uint8_t* const buf, const uint16_t mss)
 {
   Status ret = m_device.commit(len, buf, mss);
   if (ret == Status::Ok) {

--- a/src/transport/pcap/Device.cpp
+++ b/src/transport/pcap/Device.cpp
@@ -104,9 +104,9 @@ Device::process(const uint16_t len, const uint8_t* const data,
 }
 
 Status
-Device::sent(uint8_t* const data)
+Device::sent(const uint16_t len, uint8_t* const data)
 {
-  return m_proc->sent(data);
+  return m_proc->sent(len, data);
 }
 
 }

--- a/src/transport/pcap/Device.cpp
+++ b/src/transport/pcap/Device.cpp
@@ -88,6 +88,12 @@ Device::commit(const uint32_t len, uint8_t* const buf, const uint16_t mss)
 }
 
 Status
+Device::release(uint8_t* const buf)
+{
+  return m_device.release(buf);
+}
+
+Status
 Device::process(const uint16_t len, const uint8_t* const data,
                 const Timestamp ts)
 {

--- a/src/transport/shm/Device.cpp
+++ b/src/transport/shm/Device.cpp
@@ -128,7 +128,7 @@ Device::prepare(uint8_t*& buf)
 }
 
 Status
-Device::commit(const uint32_t len, uint8_t* const buf,
+Device::commit(const uint16_t len, uint8_t* const buf,
                UNUSED const uint16_t mss)
 {
   m_log.trace("SHM", "committing packet: ", len, "B, ", (void*)buf);

--- a/src/transport/shm/Device.cpp
+++ b/src/transport/shm/Device.cpp
@@ -1,8 +1,10 @@
 #include <tulips/fifo/errors.h>
+#include <tulips/fifo/fifo.h>
 #include <tulips/stack/Utils.h>
 #include <tulips/system/Clock.h>
 #include <tulips/system/Compiler.h>
 #include <tulips/transport/shm/Device.h>
+#include <cstdint>
 #include <cstdlib>
 #include <ctime>
 
@@ -19,17 +21,20 @@ Device::Device(system::Logger& log, stack::ethernet::Address const& address,
   , m_ip(ip)
   , m_dr(dr)
   , m_nm(nm)
-  , read_fifo(rf)
-  , write_fifo(wf)
+  , m_read(rf)
+  , m_write(wf)
+  , m_sent(TULIPS_FIFO_DEFAULT_VALUE)
   , m_mutex()
   , m_cond()
 {
   pthread_mutex_init(&m_mutex, nullptr);
   pthread_cond_init(&m_cond, nullptr);
+  tulips_fifo_create(m_write->depth, sizeof(uint8_t*), &m_sent);
 }
 
 Device::~Device()
 {
+  tulips_fifo_destroy(&m_sent);
   pthread_cond_destroy(&m_cond);
   pthread_mutex_destroy(&m_mutex);
 }
@@ -39,10 +44,35 @@ Device::poll(Processor& proc)
 {
   bool empty = false;
   /*
+   * Process the sent buffers.
+   */
+  while (tulips_fifo_empty(m_sent) == TULIPS_FIFO_NO) {
+    uint8_t** data = nullptr;
+    /*
+     * Get the front of the FIFO..
+     */
+    if (tulips_fifo_front(m_sent, (void**)&data) != TULIPS_FIFO_OK) {
+      return Status::HardwareError;
+    }
+    /*
+     * Pop the FIFO.
+     */
+    if (tulips_fifo_pop(m_sent) != TULIPS_FIFO_OK) {
+      return Status::HardwareError;
+    }
+    /*
+     * Notify the processor.
+     */
+    auto ret = proc.sent(*data);
+    if (ret != Status::Ok) {
+      return ret;
+    }
+  }
+  /*
    * Check the FIFO for data
    */
   for (size_t i = 0; i < RETRY_COUNT; i += 1) {
-    empty = tulips_fifo_empty(read_fifo) == TULIPS_FIFO_YES;
+    empty = tulips_fifo_empty(m_read) == TULIPS_FIFO_YES;
     if (!empty) {
       break;
     }
@@ -54,15 +84,18 @@ Device::poll(Processor& proc)
     return Status::NoDataAvailable;
   }
   /*
-   * Process the data
+   * Get the front packet.
    */
   Packet* packet = nullptr;
-  if (tulips_fifo_front(read_fifo, (void**)&packet) != TULIPS_FIFO_OK) {
+  if (tulips_fifo_front(m_read, (void**)&packet) != TULIPS_FIFO_OK) {
     return Status::HardwareError;
   }
+  /*
+   * Process the data.
+   */
   m_log.trace("SHM", "processing packet: ", size_t(packet->len), "B, ", packet);
   Status ret = proc.process(packet->len, packet->data, system::Clock::read());
-  tulips_fifo_pop(read_fifo);
+  tulips_fifo_pop(m_read);
   return ret;
 }
 
@@ -84,11 +117,11 @@ Device::wait(Processor& proc, const uint64_t ns)
 Status
 Device::prepare(uint8_t*& buf)
 {
-  if (tulips_fifo_full(write_fifo) == TULIPS_FIFO_YES) {
+  if (tulips_fifo_full(m_write) == TULIPS_FIFO_YES) {
     return Status::NoMoreResources;
   }
   Packet* packet = nullptr;
-  tulips_fifo_prepare(write_fifo, (void**)&packet);
+  tulips_fifo_prepare(m_write, (void**)&packet);
   m_log.debug("SHM", "preparing packet: ", mss(), "B, ", packet);
   buf = packet->data;
   return Status::Ok;
@@ -101,7 +134,8 @@ Device::commit(const uint32_t len, uint8_t* const buf,
   auto* packet = (Packet*)(buf - sizeof(uint32_t));
   m_log.trace("SHM", "committing packet: ", len, "B, ", packet);
   packet->len = len;
-  tulips_fifo_commit(write_fifo);
+  tulips_fifo_commit(m_write);
+  tulips_fifo_push(m_sent, &buf);
   pthread_cond_signal(&m_cond);
   return Status::Ok;
 }
@@ -110,7 +144,9 @@ Status
 Device::release(UNUSED uint8_t* const buf)
 {
   /*
-   * NOTE(xrg): the SHM device does not support out-of-order buffer release.
+   * NOTE(xrg): this device does not support processing packets out of order.
+   * The m_sent FIFO is only here to make the API functional, and assumes
+   * that the packet forwarded to Processor::sent() is still somehow valid.
    */
   return Status::Ok;
 }
@@ -118,10 +154,10 @@ Device::release(UNUSED uint8_t* const buf)
 Status
 Device::drop()
 {
-  if (tulips_fifo_empty(read_fifo) == TULIPS_FIFO_YES) {
+  if (tulips_fifo_empty(m_read) == TULIPS_FIFO_YES) {
     return Status::NoDataAvailable;
   }
-  tulips_fifo_pop(read_fifo);
+  tulips_fifo_pop(m_read);
   return Status::Ok;
 }
 
@@ -136,7 +172,7 @@ Device::waitForInput(const uint64_t ns)
   pthread_mutex_lock(&m_mutex);
   pthread_cond_timedwait(&m_cond, &m_mutex, &ts);
   pthread_mutex_unlock(&m_mutex);
-  return tulips_fifo_empty(read_fifo) == TULIPS_FIFO_YES;
+  return tulips_fifo_empty(m_read) == TULIPS_FIFO_YES;
 }
 
 }

--- a/src/transport/shm/Device.cpp
+++ b/src/transport/shm/Device.cpp
@@ -107,6 +107,15 @@ Device::commit(const uint32_t len, uint8_t* const buf,
 }
 
 Status
+Device::release(UNUSED uint8_t* const buf)
+{
+  /*
+   * NOTE(xrg): the SHM device does not support out-of-order buffer release.
+   */
+  return Status::Ok;
+}
+
+Status
 Device::drop()
 {
   if (tulips_fifo_empty(read_fifo) == TULIPS_FIFO_YES) {

--- a/tests/api/one_client.cpp
+++ b/tests/api/one_client.cpp
@@ -1,9 +1,8 @@
-#include "tulips/system/Logger.h"
 #include <tulips/api/Client.h>
 #include <tulips/api/Defaults.h>
 #include <tulips/api/Server.h>
-#include <tulips/fifo/fifo.h>
 #include <tulips/system/Compiler.h>
+#include <tulips/system/Logger.h>
 #include <tulips/transport/Processor.h>
 #include <tulips/transport/list/Device.h>
 #include <tulips/transport/pcap/Device.h>
@@ -11,6 +10,7 @@
 
 using namespace tulips;
 using namespace stack;
+using namespace transport;
 
 namespace {
 
@@ -62,8 +62,6 @@ class API_OneClient : public ::testing::Test
 public:
   API_OneClient()
     : m_logger(system::Logger::Level::Trace)
-    , m_client_fifo(nullptr)
-    , m_server_fifo(nullptr)
     , m_client_adr(0x10, 0x0, 0x0, 0x0, 0x10, 0x10)
     , m_server_adr(0x10, 0x0, 0x0, 0x0, 0x20, 0x20)
     , m_client_ip4(10, 1, 0, 1)
@@ -88,24 +86,14 @@ protected:
     std::string tname(
       ::testing::UnitTest::GetInstance()->current_test_info()->name());
     /*
-     * Create the transport FIFOs.
-     */
-    m_client_fifo = TULIPS_FIFO_DEFAULT_VALUE;
-    m_server_fifo = TULIPS_FIFO_DEFAULT_VALUE;
-    /*
-     * Build the FIFOs
-     */
-    tulips_fifo_create(64, 128, &m_client_fifo);
-    tulips_fifo_create(64, 128, &m_server_fifo);
-    /*
      * Build the devices.
      */
-    m_client_ldev =
-      new transport::list::Device(m_logger, m_client_adr, m_client_ip4, bcast,
-                                  nmask, 1514, m_server_list, m_client_list);
-    m_server_ldev =
-      new transport::list::Device(m_logger, m_server_adr, m_server_ip4, bcast,
-                                  nmask, 1514, m_client_list, m_server_list);
+    m_client_ldev = new list::Device(m_logger, m_client_adr, m_client_ip4,
+                                     bcast, nmask, 1514, m_server_list,
+                                     m_client_list);
+    m_server_ldev = new list::Device(m_logger, m_server_adr, m_server_ip4,
+                                     bcast, nmask, 1514, m_client_list,
+                                     m_server_list);
     /*
      * Build the pcap device
      */
@@ -142,24 +130,17 @@ protected:
      */
     delete m_client_ldev;
     delete m_server_ldev;
-    /*
-     * Delete the FIFOs.
-     */
-    tulips_fifo_destroy(&m_client_fifo);
-    tulips_fifo_destroy(&m_server_fifo);
   }
 
   system::ConsoleLogger m_logger;
-  tulips_fifo_t m_client_fifo;
-  tulips_fifo_t m_server_fifo;
   ethernet::Address m_client_adr;
   ethernet::Address m_server_adr;
   ipv4::Address m_client_ip4;
   ipv4::Address m_server_ip4;
-  transport::list::Device::List m_client_list;
-  transport::list::Device::List m_server_list;
-  transport::list::Device* m_client_ldev;
-  transport::list::Device* m_server_ldev;
+  list::Device::List m_client_list;
+  list::Device::List m_server_list;
+  list::Device* m_client_ldev;
+  list::Device* m_server_ldev;
   transport::pcap::Device* m_client_pcap;
   transport::pcap::Device* m_server_pcap;
   api::defaults::ClientDelegate m_client_delegate;
@@ -305,7 +286,7 @@ TEST_F(API_OneClient, ListenConnectAndCloseFromServer)
     ASSERT_EQ(Status::Ok, m_server->run());
   }
   /*
-   * Client closed
+   * Client closed.
    */
   ASSERT_TRUE(m_client->isClosed(id));
   ASSERT_TRUE(m_server->isClosed(0));

--- a/tests/api/one_client.cpp
+++ b/tests/api/one_client.cpp
@@ -210,6 +210,9 @@ TEST_F(API_OneClient, ListenConnectAndAbort)
   ASSERT_EQ(Status::Ok, m_server_pcap->poll(*m_server));
   // Client closed
   ASSERT_TRUE(m_client->isClosed(id));
+  // Client and server close the connections
+  ASSERT_EQ(Status::NoDataAvailable, m_client_pcap->poll(*m_client));
+  ASSERT_EQ(Status::NoDataAvailable, m_server_pcap->poll(*m_server));
 }
 
 TEST_F(API_OneClient, ListenConnectAndClose)
@@ -335,6 +338,13 @@ TEST_F(API_OneClient, ConnectCookie)
    * Check if the cookie was found.
    */
   ASSERT_TRUE(m_server_delegate.isListenCookieValid());
+  /*
+   * Abort the connection and clean-up.
+   */
+  ASSERT_EQ(Status::Ok, m_client->abort(id));
+  ASSERT_EQ(Status::Ok, m_server_pcap->poll(*m_server));
+  ASSERT_EQ(Status::NoDataAvailable, m_client_pcap->poll(*m_client));
+  ASSERT_EQ(Status::NoDataAvailable, m_server_pcap->poll(*m_server));
 }
 
 TEST_F(API_OneClient, ConnectTwo)
@@ -360,7 +370,6 @@ TEST_F(API_OneClient, ConnectTwo)
   ASSERT_EQ(Status::Ok, m_client->connect(id1, dst_ip, 12345));
   ASSERT_EQ(Status::NoDataAvailable, m_client_pcap->poll(*m_client));
   ASSERT_EQ(Status::NoDataAvailable, m_server_pcap->poll(*m_server));
-
   /*
    * Connection client 2.
    */
@@ -370,6 +379,17 @@ TEST_F(API_OneClient, ConnectTwo)
   ASSERT_EQ(Status::Ok, m_client_pcap->poll(*m_client));
   ASSERT_EQ(Status::Ok, m_server_pcap->poll(*m_server));
   ASSERT_EQ(Status::Ok, m_client->connect(id2, dst_ip, 12345));
+  ASSERT_EQ(Status::NoDataAvailable, m_client_pcap->poll(*m_client));
+  ASSERT_EQ(Status::NoDataAvailable, m_server_pcap->poll(*m_server));
+  /*
+   * Abort the connection and clean-up.
+   */
+  ASSERT_EQ(Status::Ok, m_client->abort(id1));
+  ASSERT_EQ(Status::Ok, m_server_pcap->poll(*m_server));
+  ASSERT_EQ(Status::NoDataAvailable, m_client_pcap->poll(*m_client));
+  ASSERT_EQ(Status::NoDataAvailable, m_server_pcap->poll(*m_server));
+  ASSERT_EQ(Status::Ok, m_client->abort(id2));
+  ASSERT_EQ(Status::Ok, m_server_pcap->poll(*m_server));
   ASSERT_EQ(Status::NoDataAvailable, m_client_pcap->poll(*m_client));
   ASSERT_EQ(Status::NoDataAvailable, m_server_pcap->poll(*m_server));
 }
@@ -433,10 +453,18 @@ TEST_F(API_OneClient, ConnectAndCloseTwo)
     ASSERT_EQ(Status::Ok, m_client->run());
     ASSERT_EQ(Status::Ok, m_server->run());
   }
+  /*
+   * Make sure the connections are closed.
+   */
   ASSERT_TRUE(m_client->isClosed(id1));
   ASSERT_TRUE(m_server->isClosed(0));
   ASSERT_TRUE(m_client->isClosed(id2));
   ASSERT_TRUE(m_server->isClosed(1));
+  /*
+   * Clean-up.
+   */
+  ASSERT_EQ(Status::NoDataAvailable, m_client_pcap->poll(*m_client));
+  ASSERT_EQ(Status::NoDataAvailable, m_server_pcap->poll(*m_server));
 }
 
 TEST_F(API_OneClient, ListenConnectSendAndAbortFromServer)

--- a/tests/api/two_clients.cpp
+++ b/tests/api/two_clients.cpp
@@ -1,8 +1,8 @@
-#include "tulips/system/Logger.h"
 #include <tulips/api/Client.h>
 #include <tulips/api/Defaults.h>
 #include <tulips/api/Server.h>
 #include <tulips/system/Compiler.h>
+#include <tulips/system/Logger.h>
 #include <tulips/transport/Processor.h>
 #include <tulips/transport/list/Device.h>
 #include <tulips/transport/pcap/Device.h>

--- a/tests/api/two_clients.cpp
+++ b/tests/api/two_clients.cpp
@@ -213,7 +213,6 @@ TEST_F(API_TwoClients, ConnectTwo)
   ASSERT_EQ(Status::Ok, m_client1->connect(id1, dst_ip, 12345));
   ASSERT_EQ(Status::NoDataAvailable, m_client_pcap->poll(*m_client1));
   ASSERT_EQ(Status::NoDataAvailable, m_server_pcap->poll(*m_server));
-
   /*
    * Connection client 2.
    */
@@ -228,6 +227,17 @@ TEST_F(API_TwoClients, ConnectTwo)
   ASSERT_EQ(Status::Ok, m_client_pcap->poll(*m_client2));
   ASSERT_EQ(Status::Ok, m_server_pcap->poll(*m_server));
   ASSERT_EQ(Status::Ok, m_client2->connect(id2, dst_ip, 12345));
+  ASSERT_EQ(Status::NoDataAvailable, m_client_pcap->poll(*m_client2));
+  ASSERT_EQ(Status::NoDataAvailable, m_server_pcap->poll(*m_server));
+  /*
+   * Abort the connection and clean-up.
+   */
+  ASSERT_EQ(Status::Ok, m_client1->abort(id1));
+  ASSERT_EQ(Status::Ok, m_server_pcap->poll(*m_server));
+  ASSERT_EQ(Status::NoDataAvailable, m_client_pcap->poll(*m_client1));
+  ASSERT_EQ(Status::NoDataAvailable, m_server_pcap->poll(*m_server));
+  ASSERT_EQ(Status::Ok, m_client2->abort(id2));
+  ASSERT_EQ(Status::Ok, m_server_pcap->poll(*m_server));
   ASSERT_EQ(Status::NoDataAvailable, m_client_pcap->poll(*m_client2));
   ASSERT_EQ(Status::NoDataAvailable, m_server_pcap->poll(*m_server));
 }
@@ -291,6 +301,21 @@ TEST_F(API_TwoClients, ConnectTwoAndDisconnectFromServer)
   ASSERT_EQ(Status::NoDataAvailable, m_server_pcap->poll(*m_server));
   ASSERT_EQ(Status::NoDataAvailable, m_client_pcap->poll(*m_client2));
   /*
+   * Advance the timers because of TIME WAIT.
+   */
+  for (int i = 0; i < 120; i += 1) {
+    system::Clock::get().offsetBy(system::Clock::SECOND);
+    ASSERT_EQ(Status::Ok, m_client1->run());
+    ASSERT_EQ(Status::Ok, m_client2->run());
+    ASSERT_EQ(Status::Ok, m_server->run());
+  }
+  /*
+   * Clean-up.
+   */
+  ASSERT_EQ(Status::NoDataAvailable, m_client_pcap->poll(*m_client1));
+  ASSERT_EQ(Status::NoDataAvailable, m_client_pcap->poll(*m_client2));
+  ASSERT_EQ(Status::NoDataAvailable, m_server_pcap->poll(*m_server));
+  /*
    * Final checks.
    */
   ASSERT_EQ(0, m_server_delegate.connections().size());
@@ -328,6 +353,13 @@ TEST_F(API_TwoClients, ConnectSend)
   ASSERT_EQ(Status::Ok, m_client_pcap->poll(*m_client1));
   ASSERT_EQ(Status::NoDataAvailable, m_server_pcap->poll(*m_server));
   ASSERT_EQ(Status::NoDataAvailable, m_client_pcap->poll(*m_client1));
+  /*
+   * Abort the connection and clean-up.
+   */
+  ASSERT_EQ(Status::Ok, m_client1->abort(id));
+  ASSERT_EQ(Status::Ok, m_server_pcap->poll(*m_server));
+  ASSERT_EQ(Status::NoDataAvailable, m_client_pcap->poll(*m_client1));
+  ASSERT_EQ(Status::NoDataAvailable, m_server_pcap->poll(*m_server));
 }
 
 TEST_F(API_TwoClients, ConnectSendReceive)
@@ -367,4 +399,11 @@ TEST_F(API_TwoClients, ConnectSendReceive)
   ASSERT_EQ(Status::NoDataAvailable, m_client_pcap->poll(*m_client1));
   ASSERT_EQ(Status::NoDataAvailable, m_server_pcap->poll(*m_server));
   ASSERT_TRUE(m_client_delegate1.dataReceived());
+  /*
+   * Abort the connection and clean-up.
+   */
+  ASSERT_EQ(Status::Ok, m_client1->abort(id));
+  ASSERT_EQ(Status::Ok, m_server_pcap->poll(*m_server));
+  ASSERT_EQ(Status::NoDataAvailable, m_client_pcap->poll(*m_client1));
+  ASSERT_EQ(Status::NoDataAvailable, m_server_pcap->poll(*m_server));
 }

--- a/tests/arp/basic.cpp
+++ b/tests/arp/basic.cpp
@@ -29,7 +29,10 @@ public:
     return Status::Ok;
   }
 
-  Status sent(UNUSED uint8_t* const data) override { return Status::Ok; }
+  Status sent(UNUSED const uint16_t len, UNUSED uint8_t* const data) override
+  {
+    return Status::Ok;
+  }
 
   uint64_t data() const { return m_data; }
 
@@ -56,7 +59,10 @@ public:
     return m_ipv4to->commit(8, outdata);
   }
 
-  Status sent(uint8_t* const data) override { return m_ipv4to->release(data); }
+  Status sent(UNUSED const uint16_t len, uint8_t* const data) override
+  {
+    return m_ipv4to->release(data);
+  }
 
   ServerProcessor& setIPv4Producer(ipv4::Producer& ip4)
   {

--- a/tests/arp/basic.cpp
+++ b/tests/arp/basic.cpp
@@ -29,6 +29,8 @@ public:
     return Status::Ok;
   }
 
+  Status sent(UNUSED uint8_t* const data) override { return Status::Ok; }
+
   uint64_t data() const { return m_data; }
 
 private:
@@ -53,6 +55,8 @@ public:
     *(uint64_t*)outdata = 0xdeadc0deULL;
     return m_ipv4to->commit(8, outdata);
   }
+
+  Status sent(uint8_t* const data) override { return m_ipv4to->release(data); }
 
   ServerProcessor& setIPv4Producer(ipv4::Producer& ip4)
   {

--- a/tests/ssl/one_client.cpp
+++ b/tests/ssl/one_client.cpp
@@ -343,9 +343,20 @@ TEST_F(SSL_OneClient, ListenConnectSendAndCloseFromServer)
   ASSERT_EQ(Status::Ok, m_client_pcap->poll(*m_client));
   ASSERT_EQ(Status::Ok, m_server_pcap->poll(*m_server));
   /*
-   * Client is closed.
+   * Advance the timers because of TIME WAIT.
+   */
+  for (int i = 0; i < 120; i += 1) {
+    system::Clock::get().offsetBy(system::Clock::SECOND);
+    ASSERT_EQ(Status::Ok, m_client->run());
+    ASSERT_EQ(Status::Ok, m_server->run());
+  }
+  /*
+   * Make sure the connection is closed.
    */
   ASSERT_TRUE(m_client->isClosed(id));
+  /*
+   * Clean-up.
+   */
   ASSERT_EQ(Status::NoDataAvailable, m_client_pcap->poll(*m_client));
   ASSERT_EQ(Status::NoDataAvailable, m_server_pcap->poll(*m_server));
 }

--- a/tests/ssl/one_client.cpp
+++ b/tests/ssl/one_client.cpp
@@ -1,9 +1,9 @@
-#include "tulips/system/Logger.h"
 #include <tulips/api/Defaults.h>
 #include <tulips/fifo/fifo.h>
 #include <tulips/ssl/Client.h>
 #include <tulips/ssl/Server.h>
 #include <tulips/system/Compiler.h>
+#include <tulips/system/Logger.h>
 #include <tulips/transport/Processor.h>
 #include <tulips/transport/list/Device.h>
 #include <tulips/transport/pcap/Device.h>

--- a/tests/ssl/two_clients.cpp
+++ b/tests/ssl/two_clients.cpp
@@ -1,8 +1,8 @@
-#include "tulips/system/Logger.h"
 #include <tulips/api/Defaults.h>
 #include <tulips/ssl/Client.h>
 #include <tulips/ssl/Server.h>
 #include <tulips/system/Compiler.h>
+#include <tulips/system/Logger.h>
 #include <tulips/transport/Processor.h>
 #include <tulips/transport/list/Device.h>
 #include <tulips/transport/pcap/Device.h>

--- a/tests/ssl/two_clients.cpp
+++ b/tests/ssl/two_clients.cpp
@@ -167,6 +167,10 @@ public:
     ASSERT_EQ(Status::Ok, m_server_pcap->poll(*m_server));
     ASSERT_EQ(Status::Ok, m_client_pcap->poll(*m_client));
     /*
+     * Advance the timers because of TIME WAIT.
+     */
+    expireTimeWait();
+    /*
      * We are closed.
      */
     ASSERT_EQ(Status::NotConnected, m_client->close(id));
@@ -209,16 +213,19 @@ public:
     ASSERT_EQ(Status::Ok, m_server_pcap->poll(*m_server));
     ASSERT_EQ(Status::Ok, m_client_pcap->poll(*m_client));
     ASSERT_EQ(Status::Ok, m_server_pcap->poll(*m_server));
-    ASSERT_EQ(Status::NoDataAvailable, m_server_pcap->poll(*m_server));
     ASSERT_EQ(Status::NoDataAvailable, m_client_pcap->poll(*m_client));
+    ASSERT_EQ(Status::NoDataAvailable, m_server_pcap->poll(*m_server));
     expireTimeWait();
     ASSERT_TRUE(m_server->isClosed(id));
+    ASSERT_EQ(Status::NoDataAvailable, m_client_pcap->poll(*m_client));
+    ASSERT_EQ(Status::NoDataAvailable, m_server_pcap->poll(*m_server));
   }
 
   void expireTimeWait()
   {
     for (int i = 0; i < tcpv4::TIME_WAIT_TIMEOUT; i += 1) {
       system::Clock::get().offsetBy(system::Clock::SECOND);
+      ASSERT_EQ(Status::Ok, m_client->run());
       ASSERT_EQ(Status::Ok, m_server->run());
     }
   }

--- a/tests/tcp/nagle.cpp
+++ b/tests/tcp/nagle.cpp
@@ -6,14 +6,15 @@
 #include <tulips/system/Compiler.h>
 #include <tulips/system/Logger.h>
 #include <tulips/transport/Processor.h>
+#include <tulips/transport/list/Device.h>
 #include <tulips/transport/pcap/Device.h>
-#include <tulips/transport/shm/Device.h>
 #include <filesystem>
 #include <fstream>
 #include <gtest/gtest.h>
 
 using namespace tulips;
 using namespace stack;
+using namespace transport;
 
 namespace {
 
@@ -203,8 +204,8 @@ class TCP_Nagle : public ::testing::Test
 public:
   TCP_Nagle()
     : m_logger(system::Logger::Level::Trace)
-    , m_client_fifo(nullptr)
-    , m_server_fifo(nullptr)
+    , m_client_fifo()
+    , m_server_fifo()
     , m_client_adr(0x10, 0x0, 0x0, 0x0, 0x10, 0x10)
     , m_server_adr(0x10, 0x0, 0x0, 0x0, 0x20, 0x20)
     , m_bcast(10, 1, 0, 254)
@@ -235,24 +236,13 @@ protected:
     std::string tname(
       ::testing::UnitTest::GetInstance()->current_test_info()->name());
     /*
-     * Create the transport FIFOs.
+     * Build the devices. NOTE(xrg): the mss size below is very important to
+     * make the tests work.
      */
-    m_client_fifo = TULIPS_FIFO_DEFAULT_VALUE;
-    m_server_fifo = TULIPS_FIFO_DEFAULT_VALUE;
-    /*
-     * Build the FIFOs
-     */
-    tulips_fifo_create(32, 128, &m_client_fifo);
-    tulips_fifo_create(32, 128, &m_server_fifo);
-    /*
-     * Build the devices.
-     */
-    m_client = new transport::shm::Device(m_logger, m_client_adr, m_client_ip4,
-                                          m_bcast, m_nmask, m_server_fifo,
-                                          m_client_fifo);
-    m_server = new transport::shm::Device(m_logger, m_server_adr, m_server_ip4,
-                                          m_bcast, m_nmask, m_client_fifo,
-                                          m_server_fifo);
+    m_client = new list::Device(m_logger, m_client_adr, m_client_ip4, m_bcast,
+                                m_nmask, 124, m_server_fifo, m_client_fifo);
+    m_server = new list::Device(m_logger, m_server_adr, m_server_ip4, m_bcast,
+                                m_nmask, 124, m_client_fifo, m_server_fifo);
     /*
      * Build the pcap device
      */
@@ -346,24 +336,19 @@ protected:
      */
     delete m_client;
     delete m_server;
-    /*
-     * Delete the FIFOs.
-     */
-    tulips_fifo_destroy(&m_client_fifo);
-    tulips_fifo_destroy(&m_server_fifo);
   }
 
   system::ConsoleLogger m_logger;
-  tulips_fifo_t m_client_fifo;
-  tulips_fifo_t m_server_fifo;
+  list::Device::List m_client_fifo;
+  list::Device::List m_server_fifo;
   ethernet::Address m_client_adr;
   ethernet::Address m_server_adr;
   ipv4::Address m_bcast;
   ipv4::Address m_nmask;
   ipv4::Address m_client_ip4;
   ipv4::Address m_server_ip4;
-  transport::shm::Device* m_client;
-  transport::shm::Device* m_server;
+  list::Device* m_client;
+  list::Device* m_server;
   transport::pcap::Device* m_client_pcap;
   transport::pcap::Device* m_server_pcap;
   Client* m_client_evt;
@@ -421,6 +406,13 @@ TEST_F(TCP_Nagle, ConnectSendNagle)
   ASSERT_EQ(Status::Ok, m_server_pcap->poll(*m_server_eth_proc));
   ASSERT_EQ(Status::Ok, m_client_pcap->poll(*m_client_eth_proc));
   ASSERT_EQ(16, m_server_evt->receivedLength());
+  /*
+   * Abort the connection and clean-up.
+   */
+  ASSERT_EQ(Status::Ok, m_client_tcp->abort(c));
+  ASSERT_EQ(Status::Ok, m_server_pcap->poll(*m_server_eth_proc));
+  ASSERT_EQ(Status::NoDataAvailable, m_client_pcap->poll(*m_client_eth_proc));
+  ASSERT_EQ(Status::NoDataAvailable, m_server_pcap->poll(*m_server_eth_proc));
 }
 
 TEST_F(TCP_Nagle, ConnectSendConsecutiveNagle)
@@ -487,6 +479,13 @@ TEST_F(TCP_Nagle, ConnectSendConsecutiveNagle)
     ASSERT_EQ(Status::Ok, m_client_pcap->poll(*m_client_eth_proc));
     ASSERT_EQ(2 * PKTLEN, m_server_evt->receivedLength());
   }
+  /*
+   * Abort the connection and clean-up.
+   */
+  ASSERT_EQ(Status::Ok, m_client_tcp->abort(c));
+  ASSERT_EQ(Status::Ok, m_server_pcap->poll(*m_server_eth_proc));
+  ASSERT_EQ(Status::NoDataAvailable, m_client_pcap->poll(*m_client_eth_proc));
+  ASSERT_EQ(Status::NoDataAvailable, m_server_pcap->poll(*m_server_eth_proc));
 }
 
 TEST_F(TCP_Nagle, ConnectSendNagleRecvThenAck)
@@ -534,4 +533,11 @@ TEST_F(TCP_Nagle, ConnectSendNagleRecvThenAck)
    */
   ASSERT_EQ(Status::Ok, m_server_pcap->poll(*m_server_eth_proc));
   ASSERT_EQ(Status::Ok, m_client_pcap->poll(*m_client_eth_proc));
+  /*
+   * Abort the connection and clean-up.
+   */
+  ASSERT_EQ(Status::Ok, m_client_tcp->abort(c));
+  ASSERT_EQ(Status::Ok, m_server_pcap->poll(*m_server_eth_proc));
+  ASSERT_EQ(Status::NoDataAvailable, m_client_pcap->poll(*m_client_eth_proc));
+  ASSERT_EQ(Status::NoDataAvailable, m_server_pcap->poll(*m_server_eth_proc));
 }

--- a/tests/tcp/nodelay.cpp
+++ b/tests/tcp/nodelay.cpp
@@ -6,14 +6,15 @@
 #include <tulips/system/Compiler.h>
 #include <tulips/system/Logger.h>
 #include <tulips/transport/Processor.h>
+#include <tulips/transport/list/Device.h>
 #include <tulips/transport/pcap/Device.h>
-#include <tulips/transport/shm/Device.h>
 #include <filesystem>
 #include <fstream>
 #include <gtest/gtest.h>
 
 using namespace tulips;
 using namespace stack;
+using namespace transport;
 
 namespace {
 
@@ -202,8 +203,8 @@ class TCP_NoDelay : public ::testing::Test
 public:
   TCP_NoDelay()
     : m_logger(system::Logger::Level::Trace)
-    , m_client_fifo(nullptr)
-    , m_server_fifo(nullptr)
+    , m_client_fifo()
+    , m_server_fifo()
     , m_client_adr(0x10, 0x0, 0x0, 0x0, 0x10, 0x10)
     , m_server_adr(0x10, 0x0, 0x0, 0x0, 0x20, 0x20)
     , m_bcast(10, 1, 0, 254)
@@ -234,24 +235,13 @@ protected:
     std::string tname(
       ::testing::UnitTest::GetInstance()->current_test_info()->name());
     /*
-     * Create the transport FIFOs.
+     * Build the devices. NOTE(xrg): the mss size below is very important to
+     * make the tests work.
      */
-    m_client_fifo = TULIPS_FIFO_DEFAULT_VALUE;
-    m_server_fifo = TULIPS_FIFO_DEFAULT_VALUE;
-    /*
-     * Build the FIFOs
-     */
-    tulips_fifo_create(32, 128, &m_client_fifo);
-    tulips_fifo_create(32, 128, &m_server_fifo);
-    /*
-     * Build the devices.
-     */
-    m_client = new transport::shm::Device(m_logger, m_client_adr, m_client_ip4,
-                                          m_bcast, m_nmask, m_server_fifo,
-                                          m_client_fifo);
-    m_server = new transport::shm::Device(m_logger, m_server_adr, m_server_ip4,
-                                          m_bcast, m_nmask, m_client_fifo,
-                                          m_server_fifo);
+    m_client = new list::Device(m_logger, m_client_adr, m_client_ip4, m_bcast,
+                                m_nmask, 124, m_server_fifo, m_client_fifo);
+    m_server = new list::Device(m_logger, m_server_adr, m_server_ip4, m_bcast,
+                                m_nmask, 124, m_client_fifo, m_server_fifo);
     /*
      * Build the pcap device
      */
@@ -345,24 +335,19 @@ protected:
      */
     delete m_client;
     delete m_server;
-    /*
-     * Delete the FIFOs.
-     */
-    tulips_fifo_destroy(&m_client_fifo);
-    tulips_fifo_destroy(&m_server_fifo);
   }
 
   system::ConsoleLogger m_logger;
-  tulips_fifo_t m_client_fifo;
-  tulips_fifo_t m_server_fifo;
+  list::Device::List m_client_fifo;
+  list::Device::List m_server_fifo;
   ethernet::Address m_client_adr;
   ethernet::Address m_server_adr;
   ipv4::Address m_bcast;
   ipv4::Address m_nmask;
   ipv4::Address m_client_ip4;
   ipv4::Address m_server_ip4;
-  transport::shm::Device* m_client;
-  transport::shm::Device* m_server;
+  list::Device* m_client;
+  list::Device* m_server;
   transport::pcap::Device* m_client_pcap;
   transport::pcap::Device* m_server_pcap;
   Client* m_client_evt;
@@ -424,6 +409,13 @@ TEST_F(TCP_NoDelay, ConnectSend)
   ASSERT_EQ(Status::Ok, m_client_pcap->poll(*m_client_eth_proc));
   ASSERT_EQ(60, m_server_evt->receivedLength());
   ASSERT_TRUE(m_server_evt->dataWasPushed());
+  /*
+   * Abort the connection and clean-up.
+   */
+  ASSERT_EQ(Status::Ok, m_client_tcp->abort(c));
+  ASSERT_EQ(Status::Ok, m_server_pcap->poll(*m_server_eth_proc));
+  ASSERT_EQ(Status::NoDataAvailable, m_client_pcap->poll(*m_client_eth_proc));
+  ASSERT_EQ(Status::NoDataAvailable, m_server_pcap->poll(*m_server_eth_proc));
   /*
    * Clean-up
    */

--- a/tests/tcp/rexmit.cpp
+++ b/tests/tcp/rexmit.cpp
@@ -6,14 +6,15 @@
 #include <tulips/system/Compiler.h>
 #include <tulips/system/Logger.h>
 #include <tulips/transport/Processor.h>
+#include <tulips/transport/list/Device.h>
 #include <tulips/transport/pcap/Device.h>
-#include <tulips/transport/shm/Device.h>
 #include <filesystem>
 #include <fstream>
 #include <gtest/gtest.h>
 
 using namespace tulips;
 using namespace stack;
+using namespace transport;
 
 namespace {
 
@@ -193,8 +194,8 @@ class TCP_Rexmit : public ::testing::Test
 public:
   TCP_Rexmit()
     : m_logger(system::Logger::Level::Trace)
-    , m_client_fifo(nullptr)
-    , m_server_fifo(nullptr)
+    , m_client_fifo()
+    , m_server_fifo()
     , m_client_adr(0x10, 0x0, 0x0, 0x0, 0x10, 0x10)
     , m_server_adr(0x10, 0x0, 0x0, 0x0, 0x20, 0x20)
     , m_bcast(10, 1, 0, 254)
@@ -225,24 +226,12 @@ protected:
     std::string tname(
       ::testing::UnitTest::GetInstance()->current_test_info()->name());
     /*
-     * Create the transport FIFOs.
-     */
-    m_client_fifo = TULIPS_FIFO_DEFAULT_VALUE;
-    m_server_fifo = TULIPS_FIFO_DEFAULT_VALUE;
-    /*
-     * Build the FIFOs
-     */
-    tulips_fifo_create(64, 128, &m_client_fifo);
-    tulips_fifo_create(64, 128, &m_server_fifo);
-    /*
      * Build the devices.
      */
-    m_client = new transport::shm::Device(m_logger, m_client_adr, m_client_ip4,
-                                          m_bcast, m_nmask, m_server_fifo,
-                                          m_client_fifo);
-    m_server = new transport::shm::Device(m_logger, m_server_adr, m_server_ip4,
-                                          m_bcast, m_nmask, m_client_fifo,
-                                          m_server_fifo);
+    m_client = new list::Device(m_logger, m_client_adr, m_client_ip4, m_bcast,
+                                m_nmask, 128, m_server_fifo, m_client_fifo);
+    m_server = new list::Device(m_logger, m_server_adr, m_server_ip4, m_bcast,
+                                m_nmask, 128, m_client_fifo, m_server_fifo);
     /*
      * Build the pcap device
      */
@@ -336,24 +325,19 @@ protected:
      */
     delete m_client;
     delete m_server;
-    /*
-     * Delete the FIFOs.
-     */
-    tulips_fifo_destroy(&m_client_fifo);
-    tulips_fifo_destroy(&m_server_fifo);
   }
 
   system::ConsoleLogger m_logger;
-  tulips_fifo_t m_client_fifo;
-  tulips_fifo_t m_server_fifo;
+  list::Device::List m_client_fifo;
+  list::Device::List m_server_fifo;
   ethernet::Address m_client_adr;
   ethernet::Address m_server_adr;
   ipv4::Address m_bcast;
   ipv4::Address m_nmask;
   ipv4::Address m_client_ip4;
   ipv4::Address m_server_ip4;
-  transport::shm::Device* m_client;
-  transport::shm::Device* m_server;
+  list::Device* m_client;
+  list::Device* m_server;
   transport::pcap::Device* m_client_pcap;
   transport::pcap::Device* m_server_pcap;
   Client* m_client_evt;
@@ -396,6 +380,13 @@ TEST_F(TCP_Rexmit, ConnectSynRetransmit)
   ASSERT_EQ(Status::Ok, m_server_pcap->poll(*m_server_eth_proc));
   ASSERT_TRUE(m_client_evt->isConnected());
   ASSERT_TRUE(m_server_evt->isConnected());
+  /*
+   * Abort the connection and clean-up.
+   */
+  ASSERT_EQ(Status::Ok, m_client_tcp->abort(c));
+  ASSERT_EQ(Status::Ok, m_server_pcap->poll(*m_server_eth_proc));
+  ASSERT_EQ(Status::NoDataAvailable, m_client_pcap->poll(*m_client_eth_proc));
+  ASSERT_EQ(Status::NoDataAvailable, m_server_pcap->poll(*m_server_eth_proc));
 }
 
 TEST_F(TCP_Rexmit, ConnectSynAckRetransmit)
@@ -424,6 +415,13 @@ TEST_F(TCP_Rexmit, ConnectSynAckRetransmit)
   ASSERT_EQ(Status::Ok, m_server_pcap->poll(*m_server_eth_proc));
   ASSERT_TRUE(m_client_evt->isConnected());
   ASSERT_TRUE(m_server_evt->isConnected());
+  /*
+   * Abort the connection and clean-up.
+   */
+  ASSERT_EQ(Status::Ok, m_client_tcp->abort(c));
+  ASSERT_EQ(Status::Ok, m_server_pcap->poll(*m_server_eth_proc));
+  ASSERT_EQ(Status::NoDataAvailable, m_client_pcap->poll(*m_client_eth_proc));
+  ASSERT_EQ(Status::NoDataAvailable, m_server_pcap->poll(*m_server_eth_proc));
 }
 
 TEST_F(TCP_Rexmit, ConnectSendRetransmit)
@@ -461,4 +459,11 @@ TEST_F(TCP_Rexmit, ConnectSendRetransmit)
   ASSERT_EQ(Status::Ok, m_server->drop());
   ASSERT_EQ(Status::Ok, m_server_pcap->poll(*m_server_eth_proc));
   ASSERT_EQ(Status::Ok, m_client_pcap->poll(*m_client_eth_proc));
+  /*
+   * Abort the connection and clean-up.
+   */
+  ASSERT_EQ(Status::Ok, m_client_tcp->abort(c));
+  ASSERT_EQ(Status::Ok, m_server_pcap->poll(*m_server_eth_proc));
+  ASSERT_EQ(Status::NoDataAvailable, m_client_pcap->poll(*m_client_eth_proc));
+  ASSERT_EQ(Status::NoDataAvailable, m_server_pcap->poll(*m_server_eth_proc));
 }

--- a/tests/tcp/transmit.cpp
+++ b/tests/tcp/transmit.cpp
@@ -6,14 +6,15 @@
 #include <tulips/system/Compiler.h>
 #include <tulips/system/Logger.h>
 #include <tulips/transport/Processor.h>
+#include <tulips/transport/list/Device.h>
 #include <tulips/transport/pcap/Device.h>
-#include <tulips/transport/shm/Device.h>
 #include <filesystem>
 #include <fstream>
 #include <gtest/gtest.h>
 
 using namespace tulips;
 using namespace stack;
+using namespace transport;
 
 namespace {
 
@@ -236,8 +237,8 @@ class TCP_Transmit : public ::testing::Test
 public:
   TCP_Transmit()
     : m_logger(system::Logger::Level::Trace)
-    , m_client_fifo(nullptr)
-    , m_server_fifo(nullptr)
+    , m_client_fifo()
+    , m_server_fifo()
     , m_client_adr(0x10, 0x0, 0x0, 0x0, 0x10, 0x10)
     , m_server_adr(0x10, 0x0, 0x0, 0x0, 0x20, 0x20)
     , m_bcast(10, 1, 0, 254)
@@ -268,24 +269,12 @@ protected:
     std::string tname(
       ::testing::UnitTest::GetInstance()->current_test_info()->name());
     /*
-     * Create the transport FIFOs.
-     */
-    m_client_fifo = TULIPS_FIFO_DEFAULT_VALUE;
-    m_server_fifo = TULIPS_FIFO_DEFAULT_VALUE;
-    /*
-     * Build the FIFOs
-     */
-    tulips_fifo_create(64, 128, &m_client_fifo);
-    tulips_fifo_create(64, 128, &m_server_fifo);
-    /*
      * Build the devices.
      */
-    m_client = new transport::shm::Device(m_logger, m_client_adr, m_client_ip4,
-                                          m_bcast, m_nmask, m_server_fifo,
-                                          m_client_fifo);
-    m_server = new transport::shm::Device(m_logger, m_server_adr, m_server_ip4,
-                                          m_bcast, m_nmask, m_client_fifo,
-                                          m_server_fifo);
+    m_client = new list::Device(m_logger, m_client_adr, m_client_ip4, m_bcast,
+                                m_nmask, 128, m_server_fifo, m_client_fifo);
+    m_server = new list::Device(m_logger, m_server_adr, m_server_ip4, m_bcast,
+                                m_nmask, 128, m_client_fifo, m_server_fifo);
     /*
      * Build the pcap device
      */
@@ -379,24 +368,19 @@ protected:
      */
     delete m_client;
     delete m_server;
-    /*
-     * Delete the FIFOs.
-     */
-    tulips_fifo_destroy(&m_client_fifo);
-    tulips_fifo_destroy(&m_server_fifo);
   }
 
   system::ConsoleLogger m_logger;
-  tulips_fifo_t m_client_fifo;
-  tulips_fifo_t m_server_fifo;
+  list::Device::List m_client_fifo;
+  list::Device::List m_server_fifo;
   ethernet::Address m_client_adr;
   ethernet::Address m_server_adr;
   ipv4::Address m_bcast;
   ipv4::Address m_nmask;
   ipv4::Address m_client_ip4;
   ipv4::Address m_server_ip4;
-  transport::shm::Device* m_client;
-  transport::shm::Device* m_server;
+  list::Device* m_client;
+  list::Device* m_server;
   transport::pcap::Device* m_client_pcap;
   transport::pcap::Device* m_server_pcap;
   Client* m_client_evt;
@@ -443,6 +427,13 @@ TEST_F(TCP_Transmit, ConnectSend)
   ASSERT_EQ(8, res);
   ASSERT_EQ(Status::Ok, m_server_pcap->poll(*m_server_eth_proc));
   ASSERT_EQ(Status::Ok, m_client_pcap->poll(*m_client_eth_proc));
+  /*
+   * Abort the connection and clean-up.
+   */
+  ASSERT_EQ(Status::Ok, m_client_tcp->abort(c));
+  ASSERT_EQ(Status::Ok, m_server_pcap->poll(*m_server_eth_proc));
+  ASSERT_EQ(Status::NoDataAvailable, m_client_pcap->poll(*m_client_eth_proc));
+  ASSERT_EQ(Status::NoDataAvailable, m_server_pcap->poll(*m_server_eth_proc));
 }
 
 TEST_F(TCP_Transmit, ConnectSendWithResponse)
@@ -481,6 +472,13 @@ TEST_F(TCP_Transmit, ConnectSendWithResponse)
   ASSERT_EQ(Status::Ok, m_server_pcap->poll(*m_server_eth_proc));
   ASSERT_EQ(Status::Ok, m_client_pcap->poll(*m_client_eth_proc));
   ASSERT_EQ(Status::Ok, m_server_pcap->poll(*m_server_eth_proc));
+  /*
+   * Abort the connection and clean-up.
+   */
+  ASSERT_EQ(Status::Ok, m_client_tcp->abort(c));
+  ASSERT_EQ(Status::Ok, m_server_pcap->poll(*m_server_eth_proc));
+  ASSERT_EQ(Status::NoDataAvailable, m_client_pcap->poll(*m_client_eth_proc));
+  ASSERT_EQ(Status::NoDataAvailable, m_server_pcap->poll(*m_server_eth_proc));
 }
 
 TEST_F(TCP_Transmit, ConnectSendDisconnectFromClient)
@@ -520,6 +518,17 @@ TEST_F(TCP_Transmit, ConnectSendDisconnectFromClient)
   ASSERT_EQ(Status::Ok, m_server_pcap->poll(*m_server_eth_proc));
   ASSERT_EQ(Status::Ok, m_client_pcap->poll(*m_client_eth_proc));
   ASSERT_EQ(Status::Ok, m_server_pcap->poll(*m_server_eth_proc));
+  /*
+   * Advance the timers because of TIME WAIT.
+   */
+  for (int i = 0; i < 120; i += 1) {
+    system::Clock::get().offsetBy(system::Clock::SECOND);
+    ASSERT_EQ(Status::Ok, m_client_eth_proc->run());
+    ASSERT_EQ(Status::Ok, m_server_eth_proc->run());
+  }
+  /*
+   * Client closed.
+   */
   ASSERT_EQ(Status::NoDataAvailable, m_client_pcap->poll(*m_client_eth_proc));
   ASSERT_EQ(Status::NoDataAvailable, m_server_pcap->poll(*m_server_eth_proc));
 }
@@ -564,6 +573,19 @@ TEST_F(TCP_Transmit, ConnectSendDisconnectFromServer)
    * Client disconnects, server closes
    */
   ASSERT_EQ(Status::NotConnected, m_client_tcp->close(c));
+  /*
+   * Advance the timers because of TIME WAIT.
+   */
+  for (int i = 0; i < 120; i += 1) {
+    system::Clock::get().offsetBy(system::Clock::SECOND);
+    ASSERT_EQ(Status::Ok, m_client_eth_proc->run());
+    ASSERT_EQ(Status::Ok, m_server_eth_proc->run());
+  }
+  /*
+   * Client closed.
+   */
+  ASSERT_EQ(Status::NoDataAvailable, m_client_pcap->poll(*m_client_eth_proc));
+  ASSERT_EQ(Status::NoDataAvailable, m_server_pcap->poll(*m_server_eth_proc));
 }
 
 TEST_F(TCP_Transmit, ConnectSendDisconnectFromServerWithAckCombining)
@@ -610,6 +632,19 @@ TEST_F(TCP_Transmit, ConnectSendDisconnectFromServerWithAckCombining)
    * Client disconnects, server closes
    */
   ASSERT_EQ(Status::NotConnected, m_client_tcp->close(c));
+  /*
+   * Advance the timers because of TIME WAIT.
+   */
+  for (int i = 0; i < 120; i += 1) {
+    system::Clock::get().offsetBy(system::Clock::SECOND);
+    ASSERT_EQ(Status::Ok, m_client_eth_proc->run());
+    ASSERT_EQ(Status::Ok, m_server_eth_proc->run());
+  }
+  /*
+   * Client closed.
+   */
+  ASSERT_EQ(Status::NoDataAvailable, m_client_pcap->poll(*m_client_eth_proc));
+  ASSERT_EQ(Status::NoDataAvailable, m_server_pcap->poll(*m_server_eth_proc));
 }
 
 TEST_F(TCP_Transmit, ConnectSendAbortFromClient)

--- a/tests/transport/basic.cpp
+++ b/tests/transport/basic.cpp
@@ -41,7 +41,10 @@ public:
     return Status::IncompleteData;
   }
 
-  Status sent(uint8_t* const data) override { return m_prod->release(data); }
+  Status sent(UNUSED const uint16_t len, uint8_t* const data) override
+  {
+    return m_prod->release(data);
+  }
 
   size_t value() const { return m_value; }
 
@@ -74,7 +77,10 @@ public:
     return m_prod->commit(sizeof(m_value), outdata);
   }
 
-  Status sent(uint8_t* const data) override { return m_prod->release(data); }
+  Status sent(UNUSED const uint16_t len, uint8_t* const data) override
+  {
+    return m_prod->release(data);
+  }
 
   size_t value() const { return m_value; }
 
@@ -128,7 +134,8 @@ TEST(Transport_Basic, SharedMemory)
   /*
    * Create the console logger.
    */
-  auto logger = system::ConsoleLogger(system::Logger::Level::Trace);
+  auto log0 = system::ConsoleLogger(system::Logger::Level::Trace);
+  auto log1 = system::ConsoleLogger(system::Logger::Level::Trace);
   /*
    * Build the FIFOs
    */
@@ -143,9 +150,9 @@ TEST(Transport_Basic, SharedMemory)
   stack::ipv4::Address server_ip4(10, 1, 0, 2);
   stack::ipv4::Address bcast(10, 1, 0, 254);
   stack::ipv4::Address nmask(255, 255, 255, 0);
-  transport::shm::Device client(logger, client_adr, client_ip4, bcast, nmask,
+  transport::shm::Device client(log0, client_adr, client_ip4, bcast, nmask,
                                 server_fifo, client_fifo);
-  transport::shm::Device server(logger, server_adr, server_ip4, bcast, nmask,
+  transport::shm::Device server(log1, server_adr, server_ip4, bcast, nmask,
                                 client_fifo, server_fifo);
   /*
    * Start the threads

--- a/tests/transport/basic.cpp
+++ b/tests/transport/basic.cpp
@@ -41,6 +41,8 @@ public:
     return Status::IncompleteData;
   }
 
+  Status sent(uint8_t* const data) override { return m_prod->release(data); }
+
   size_t value() const { return m_value; }
 
   ClientProcessor& setProducer(transport::Producer& prod)
@@ -71,6 +73,8 @@ public:
     memcpy(outdata, &m_value, sizeof(size_t));
     return m_prod->commit(sizeof(m_value), outdata);
   }
+
+  Status sent(uint8_t* const data) override { return m_prod->release(data); }
 
   size_t value() const { return m_value; }
 


### PR DESCRIPTION
The prepared buffers in the TCP segments could be reallocated by the device and therefore overwritten before the segment was acknowledged, causing data corruption (and connection reset) upon retransmission.

I introduced an extended `Producer`/`Processor` API to let buffer consumers release those buffers on their own terms:

1. `Producer::release(buffer)`: release the buffer to the pool;
2. `Processor::sent(buffer)`: the buffer has been sent;

Those APIs are supposed to be used together. When no extra care is required on `::sent()`, the buffer can be immediately `::released()`.  When buffers need to be released at a later date (for example TCP segments), `::sent()` can be left empty and the user can call `::released()` when needed.