### PR TITLE
Generate build definitions to avoid type memory layout mismatch

### DIFF
--- a/.github/workflows/tulips.yml
+++ b/.github/workflows/tulips.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 jobs:
-  build-debug-and-test:
+  build-debug-and-test-with-clang:
     runs-on: ubuntu-latest
     container: 
       image: xenogenics/tulips-builder
@@ -22,11 +22,43 @@ jobs:
         run: make build
       - name: test
         run: make test
-  build-release:
+  build-debug-and-test-with-gcc:
     runs-on: ubuntu-latest
     container: 
       image: xenogenics/tulips-builder
       env:
+        CC: gcc
+        CXX: g++
+        CTEST_PARALLEL_LEVEL: 2
+      options: --cpus 2
+    steps:
+      - uses: actions/checkout@v3
+      - name: cmake
+        run: make debug-all
+      - name: build
+        run: make build
+      - name: test
+        run: make test
+  build-release-with-clang:
+    runs-on: ubuntu-latest
+    container: 
+      image: xenogenics/tulips-builder
+      env:
+        CTEST_PARALLEL_LEVEL: 2
+      options: --cpus 2
+    steps:
+      - uses: actions/checkout@v3
+      - name: cmake
+        run: make release-all
+      - name: build
+        run: make build
+  build-release-with-gcc:
+    runs-on: ubuntu-latest
+    container: 
+      image: xenogenics/tulips-builder
+      env:
+        CC: gcc
+        CXX: g++
         CTEST_PARALLEL_LEVEL: 2
       options: --cpus 2
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,10 +108,8 @@ if (TULIPS_TESTS)
 
   add_definitions(-DTULIPS_TESTS)
   add_definitions(-DTULIPS_CLOCK_HAS_OFFSET)
-  add_definitions(-DTULIPS_FIFO_RUNTIME_CHECKS)
   add_definitions(-DTULIPS_STACK_RUNTIME_CHECKS)
   add_definitions(-DTULIPS_TRANSPORT_RUNTIME_CHECKS)
-
   add_definitions(-DTULIPS_SOURCE_ROOT="${CMAKE_SOURCE_DIR}")
 
   message(STATUS "Test mode: ON")
@@ -219,6 +217,14 @@ if (${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
 endif ()
 
 #
+# Configure the config.h file
+#
+
+configure_file (
+  ${PROJECT_SOURCE_DIR}/include/tulips/config.h.in
+  ${PROJECT_BINARY_DIR}/include/tulips/config.h)
+
+#
 # Include directories
 #
 
@@ -248,7 +254,18 @@ endif (TULIPS_TESTS)
 # Install all headers
 #
 
-install(DIRECTORY include/tulips DESTINATION include PATTERN "*.swp" EXCLUDE)
+install(
+  DIRECTORY include/tulips
+  DESTINATION include
+  PATTERN "*.in" EXCLUDE
+  PATTERN "*.swp" EXCLUDE
+)
+
+install(
+  DIRECTORY ${CMAKE_BINARY_DIR}/include/tulips
+  DESTINATION include
+  PATTERN "*.swp" EXCLUDE
+)
 
 #
 # Formatting

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,8 @@ option(TULIPS_ENABLE_ICMP "Enable ICMP support" OFF)
 option(TULIPS_ENABLE_RAW "Enable RAW support" OFF)
 
 option(TULIPS_ENABLE_LATENCY_MONITOR "Enable client latency monitoring" OFF)
-option(TULIPS_ENABLE_SANITIZERS "Enable code sanitizers" OFF)
+option(TULIPS_ENABLE_ASAN "Enable address sanitizer" OFF)
+option(TULIPS_ENABLE_UBSAN "Enable undefined behavior sanitizer" OFF)
 
 option(TULIPS_DISABLE_CHECKSUM_CHECK "Disable checksum checks" OFF)
 option(TULIPS_HAS_HW_CHECKSUM "Target has hardware checksum" OFF)
@@ -75,7 +76,21 @@ if (TULIPS_TESTS)
 endif (TULIPS_TESTS)
 
 #
-# Option processing
+# Compiler flags
+#
+
+set(CMAKE_C_FLAGS "-Wall -Wextra -Werror -Wfatal-errors -mssse3")
+set(CMAKE_C_FLAGS_DEBUG "-g3 -O0")
+set(CMAKE_C_FLAGS_RELEASE "-O3")
+set(CMAKE_C_FLAGS_RELWITHDEBINFO "-g3 -O3")
+
+set(CMAKE_CXX_FLAGS "-Wall -Wextra -Werror -Wfatal-errors -mssse3")
+set(CMAKE_CXX_FLAGS_DEBUG "-g3 -O0")
+set(CMAKE_CXX_FLAGS_RELEASE "-O3")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-g3 -O3")
+
+#
+# Option definitions
 #
 
 message(STATUS "[ TULIPS COMPILATION OPTIONS ]")
@@ -85,7 +100,9 @@ if (TULIPS_TESTS)
   set(TULIPS_ENABLE_ARP ON)
   set(TULIPS_ENABLE_ICMP ON)
   set(TULIPS_ENABLE_RAW ON)
-  set(TULIPS_ENABLE_SANITIZERS ON)
+
+  set(TULIPS_ENABLE_ASAN ON)
+  set(TULIPS_ENABLE_UBSAN ON)
 
   set(TULIPS_IGNORE_INCOMPATIBLE_HW ON)
 
@@ -101,11 +118,25 @@ if (TULIPS_TESTS)
 
 endif (TULIPS_TESTS)
 
-if (TULIPS_ENABLE_SANITIZERS)
-  message(STATUS "Sanitizers: ON")
-else (TULIPS_ENABLE_SANITIZERS)
-  message(STATUS "Sanitizers: OFF")
-endif (TULIPS_ENABLE_SANITIZERS)
+#
+# Compilation options
+#
+
+if (TULIPS_ENABLE_ASAN)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
+  add_link_options(-fsanitize=address)
+  message(STATUS "Address sanitizer: ON")
+endif (TULIPS_ENABLE_ASAN)
+
+if (TULIPS_ENABLE_UBSAN)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=undefined")
+  add_link_options(-fsanitize=undefined)
+  message(STATUS "Undefined behavior sanitizer: ON")
+endif (TULIPS_ENABLE_UBSAN)
+
+#
+# Offload options
+#
 
 message(STATUS "[ TULIPS OFFLOAD OPTIONS ]")
 
@@ -167,28 +198,11 @@ else (TULIPS_ENABLE_LATENCY_MONITOR)
   message(STATUS "Client latency monitor: OFF")
 endif (TULIPS_ENABLE_LATENCY_MONITOR)
 
+#
+# Done with options.
+#
+
 message(STATUS "[ TULIPS OPTIONS END ]")
-
-#
-# Flags preferences
-#
-
-set(CMAKE_C_FLAGS "-Wall -Wextra -Werror -Wfatal-errors -mssse3")
-set(CMAKE_C_FLAGS_DEBUG "-g3 -O0")
-set(CMAKE_C_FLAGS_RELEASE "-O3")
-set(CMAKE_C_FLAGS_RELWITHDEBINFO "-g3 -O3")
-
-set(CMAKE_CXX_FLAGS "-Wall -Wextra -Werror -Wfatal-errors -mssse3")
-set(CMAKE_CXX_FLAGS_DEBUG "-g3 -O0")
-set(CMAKE_CXX_FLAGS_RELEASE "-O3")
-set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-g3 -O3")
-
-if (TULIPS_ENABLE_SANITIZERS)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
-  add_link_options(-fsanitize=address)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=undefined")
-  add_link_options(-fsanitize=undefined)
-endif (TULIPS_ENABLE_SANITIZERS)
 
 #
 # Per-compiler options

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,9 @@ release-lib:
 	 cmake -G Ninja $(RELFLAGS) -DTULIPS_TOOLS=OFF $(EXTFLAGS) ..;	\
 	 cd ..
 
+install:
+	@[ -e $(BUILDDIR) ] && ninja -C $(BUILDDIR) install
+
 clean:
 	@rm -rf $(BUILDDIR)
 	@rm -f *.keys *.log *.pcap

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -52,6 +52,8 @@ RUN apt install -y    \
       clang-tidy-15   \
       cmake           \
       dpdk-dev        \
+      gcc             \
+      g++             \
       make            \
       ninja-build     \
       libgtest-dev    \

--- a/include/tulips/api/Client.h
+++ b/include/tulips/api/Client.h
@@ -75,23 +75,14 @@ public:
 
   bool isClosed(const ID id) const override;
 
+  Status get(const ID id, stack::ipv4::Address& ripaddr,
+             stack::tcpv4::Port& lport,
+             stack::tcpv4::Port& rport) const override;
+
   Status send(const ID id, const uint32_t len, const uint8_t* const data,
               uint32_t& off) override;
 
   system::Clock::Value averageLatency(const ID id) override;
-
-  /**
-   * Get information about a connection.
-   *
-   * @param id the connection's handle.
-   * @param ripaddr the connection's remote IP address.
-   * @param lport the connection's local port.
-   * @param rport the connection's remote port.
-   *
-   * @return the status of the operation.
-   */
-  Status get(const ID id, stack::ipv4::Address& ripaddr,
-             stack::tcpv4::Port& lport, stack::tcpv4::Port& rport);
 
   /*
    * @param id the connection's handle.

--- a/include/tulips/api/Client.h
+++ b/include/tulips/api/Client.h
@@ -35,7 +35,7 @@ public:
    */
   Client(system::Logger& log, Delegate& dlg, transport::Device& device,
          const size_t nconn);
-  ~Client() override = default;
+  ~Client() override;
 
   /**
    * Device interface.
@@ -92,8 +92,6 @@ public:
   void* cookie(const ID id) const;
 
 private:
-  using Connections = std::vector<Connection>;
-
 #ifdef TULIPS_ENABLE_RAW
   class RawProcessor : public Processor
   {
@@ -150,7 +148,7 @@ private:
   RawProcessor m_raw;
 #endif
   stack::tcpv4::Processor m_tcp;
-  Connections m_cns;
+  Connection* m_cns;
 };
 
 }

--- a/include/tulips/api/Client.h
+++ b/include/tulips/api/Client.h
@@ -35,7 +35,7 @@ public:
    */
   Client(system::Logger& log, Delegate& dlg, transport::Device& device,
          const size_t nconn);
-  ~Client() override;
+  ~Client() override = default;
 
   /**
    * Device interface.
@@ -92,6 +92,8 @@ public:
   void* cookie(const ID id) const;
 
 private:
+  using Connections = std::vector<Connection>;
+
 #ifdef TULIPS_ENABLE_RAW
   class RawProcessor : public Processor
   {
@@ -148,7 +150,7 @@ private:
   RawProcessor m_raw;
 #endif
   stack::tcpv4::Processor m_tcp;
-  Connection* m_cns;
+  Connections m_cns;
 };
 
 }

--- a/include/tulips/api/Client.h
+++ b/include/tulips/api/Client.h
@@ -58,6 +58,8 @@ public:
    * Client interface.
    */
 
+  bool live() const override;
+
   using interface::Client::open;
 
   Status open(const uint8_t options, ID& id) override;

--- a/include/tulips/api/Interface.h
+++ b/include/tulips/api/Interface.h
@@ -207,6 +207,20 @@ public:
   virtual bool isClosed(const ID id) const = 0;
 
   /**
+   * Get information about a connection.
+   *
+   * @param id the connection's handle.
+   * @param ripaddr the connection's remote IP address.
+   * @param lport the connection's local port.
+   * @param rport the connection's remote port.
+   *
+   * @return the status of the operation.
+   */
+  virtual Status get(const ID id, stack::ipv4::Address& ripaddr,
+                     stack::tcpv4::Port& lport,
+                     stack::tcpv4::Port& rport) const = 0;
+
+  /**
    * Send data through a connection. May send partial data.
    *
    * @param id the connection's handle.

--- a/include/tulips/api/Interface.h
+++ b/include/tulips/api/Interface.h
@@ -128,6 +128,11 @@ public:
   static constexpr ID DEFAULT_ID = -1;
 
   /**
+   * @return whether or not the client has live connections.
+   */
+  virtual bool live() const = 0;
+
+  /**
    * Open a new connection.
    *
    * @param id the new connection handle.

--- a/include/tulips/config.h.in
+++ b/include/tulips/config.h.in
@@ -1,0 +1,24 @@
+#pragma once
+
+/*
+ * Performance.
+ */
+
+#cmakedefine TULIPS_ENABLE_LATENCY_MONITOR
+
+/*
+ * Hardware offloads.
+ */
+
+#cmakedefine TULIPS_DISABLE_CHECKSUM_CHECK
+#cmakedefine TULIPS_HAS_HW_CHECKSUM
+#cmakedefine TULIPS_HAS_HW_TSO
+#cmakedefine TULIPS_IGNORE_INCOMPATIBLE_HW
+
+/*
+ * Protocols.
+ */
+
+#cmakedefine TULIPS_ENABLE_ARP
+#cmakedefine TULIPS_ENABLE_ICMP
+#cmakedefine TULIPS_ENABLE_RAW 

--- a/include/tulips/ssl/Client.h
+++ b/include/tulips/ssl/Client.h
@@ -49,6 +49,8 @@ public:
    * Client interface.
    */
 
+  bool live() const override;
+
   using api::interface::Client::open;
 
   Status open(const uint8_t options, ID& id) override;

--- a/include/tulips/ssl/Client.h
+++ b/include/tulips/ssl/Client.h
@@ -66,6 +66,10 @@ public:
 
   bool isClosed(const ID id) const override;
 
+  Status get(const ID id, stack::ipv4::Address& ripaddr,
+             stack::tcpv4::Port& lport,
+             stack::tcpv4::Port& rport) const override;
+
   Status send(const ID id, const uint32_t len, const uint8_t* const data,
               uint32_t& off) override;
 

--- a/include/tulips/ssl/Client.h
+++ b/include/tulips/ssl/Client.h
@@ -32,17 +32,17 @@ public:
    * Processor interface.
    */
 
-  inline Status run() override { return m_client->run(); }
+  inline Status run() override { return m_client.run(); }
 
   inline Status process(const uint16_t len, const uint8_t* const data,
                         const Timestamp ts) override
   {
-    return m_client->process(len, data, ts);
+    return m_client.process(len, data, ts);
   }
 
   inline Status sent(const uint16_t len, uint8_t* const data) override
   {
-    return m_client->sent(len, data);
+    return m_client.sent(len, data);
   }
 
   /**
@@ -98,7 +98,7 @@ private:
 
   api::interface::Client::Delegate& m_delegate;
   system::Logger& m_log;
-  std::unique_ptr<tulips::api::Client> m_client;
+  tulips::api::Client m_client;
   void* m_context;
   bool m_savekeys;
 };

--- a/include/tulips/stack/tcpv4/Processor.h
+++ b/include/tulips/stack/tcpv4/Processor.h
@@ -108,7 +108,7 @@ public:
               const uint8_t* const data, uint32_t& off);
 
   Status get(const Connection::ID id, ipv4::Address& ripaddr, Port& lport,
-             Port& rport);
+             Port& rport) const;
 
   void* cookie(const Connection::ID id) const;
 

--- a/include/tulips/stack/tcpv4/Processor.h
+++ b/include/tulips/stack/tcpv4/Processor.h
@@ -34,7 +34,7 @@ static constexpr int USED TIME_WAIT_TIMEOUT = 120;
 struct Statistics
 {
   uint64_t drop;    // Number of dropped TCP segments.
-  uint64_t recv;    // Number of recived TCP segments.
+  uint64_t recv;    // Number of received TCP segments.
   uint64_t sent;    // Number of sent TCP segments.
   uint64_t chkerr;  // Number of TCP segments with a bad checksum.
   uint64_t ackerr;  // Number of TCP segments with a bad ACK number.

--- a/include/tulips/transport/ena/AbstractionLayer.h
+++ b/include/tulips/transport/ena/AbstractionLayer.h
@@ -2,17 +2,22 @@
 
 #include <tulips/system/Logger.h>
 #include <cstdio>
+#include <memory>
 
 namespace tulips::transport::ena {
 
 class AbstractionLayer
 {
 public:
-  AbstractionLayer(system::Logger& logger);
+  using Ref = std::unique_ptr<AbstractionLayer>;
+
+  static Ref allocate(system::Logger& logger);
+
   ~AbstractionLayer();
 
 private:
-  char* m_args[7];
+  AbstractionLayer(FILE* const logfile);
+
   FILE* m_logfile;
 };
 

--- a/include/tulips/transport/ena/AbstractionLayer.h
+++ b/include/tulips/transport/ena/AbstractionLayer.h
@@ -12,6 +12,7 @@ public:
   ~AbstractionLayer();
 
 private:
+  char* m_args[7];
   FILE* m_logfile;
 };
 

--- a/include/tulips/transport/ena/Port.h
+++ b/include/tulips/transport/ena/Port.h
@@ -4,7 +4,6 @@
 #include <tulips/stack/IPv4.h>
 #include <tulips/system/Logger.h>
 #include <tulips/transport/Device.h>
-#include <tulips/transport/ena/AbstractionLayer.h>
 #include <tulips/transport/ena/RawProcessor.h>
 #include <list>
 #include <string>
@@ -42,7 +41,6 @@ private:
   }
 
   system::Logger& m_log;
-  AbstractionLayer m_eal;
   size_t m_depth;
   uint16_t m_portid;
   stack::ethernet::Address m_address;

--- a/include/tulips/transport/list/Device.h
+++ b/include/tulips/transport/list/Device.h
@@ -29,7 +29,7 @@ public:
     static void release(Packet* packet) { free(packet); }
 
     Packet() = delete;
-    Packet(const uint32_t mtu) : mtu(mtu), len(0), data() {}
+    Packet(const uint32_t mtu) : mtu(mtu), len(0) {}
 
     Packet* clone() const
     {

--- a/src/api/Client.cpp
+++ b/src/api/Client.cpp
@@ -72,6 +72,23 @@ Client::Client(system::Logger& log, Delegate& dlg, transport::Device& device,
   m_cns.resize(nconn);
 }
 
+bool
+Client::live() const
+{
+  /*
+   * True if any connection is not closed.
+   */
+  for (auto const& c : m_cns) {
+    if (c.state() != Connection::State::Closed) {
+      return true;
+    }
+  }
+  /*
+   * False otherwise.
+   */
+  return false;
+}
+
 Status
 Client::open(const uint8_t options, ID& id)
 {

--- a/src/api/Client.cpp
+++ b/src/api/Client.cpp
@@ -31,7 +31,7 @@ Client::Client(system::Logger& log, Delegate& dlg, transport::Device& device,
   , m_raw()
 #endif
   , m_tcp(log, device, m_ethto, m_ip4to, *this, nconn)
-  , m_cns(nullptr)
+  , m_cns()
 {
   /*
    * Hint the device about checksum.
@@ -69,12 +69,7 @@ Client::Client(system::Logger& log, Delegate& dlg, transport::Device& device,
   /*
    * Reserve connections.
    */
-  m_cns = new Connection[nconn];
-}
-
-Client::~Client()
-{
-  delete[] m_cns;
+  m_cns.resize(nconn);
 }
 
 Status

--- a/src/api/Client.cpp
+++ b/src/api/Client.cpp
@@ -31,7 +31,7 @@ Client::Client(system::Logger& log, Delegate& dlg, transport::Device& device,
   , m_raw()
 #endif
   , m_tcp(log, device, m_ethto, m_ip4to, *this, nconn)
-  , m_cns()
+  , m_cns(nullptr)
 {
   /*
    * Hint the device about checksum.
@@ -69,7 +69,12 @@ Client::Client(system::Logger& log, Delegate& dlg, transport::Device& device,
   /*
    * Reserve connections.
    */
-  m_cns.resize(nconn);
+  m_cns = new Connection[nconn];
+}
+
+Client::~Client()
+{
+  delete[] m_cns;
 }
 
 Status

--- a/src/api/Client.cpp
+++ b/src/api/Client.cpp
@@ -305,6 +305,22 @@ Client::isClosed(const ID id) const
 }
 
 Status
+Client::get(const ID id, stack::ipv4::Address& ripaddr,
+            stack::tcpv4::Port& lport, stack::tcpv4::Port& rport) const
+{
+  /*
+   * Check if connection ID is valid.
+   */
+  if (id >= m_nconn) {
+    return Status::InvalidConnection;
+  }
+  /*
+   * Get the info.
+   */
+  return m_tcp.get(id, ripaddr, lport, rport);
+}
+
+Status
 Client::send(const ID id, const uint32_t len, const uint8_t* const data,
              uint32_t& off)
 {
@@ -327,22 +343,6 @@ Client::send(const ID id, const uint32_t len, const uint8_t* const data,
   c.pre = c.pre ?: system::Clock::read();
 #endif
   return m_tcp.send(id, len, data, off);
-}
-
-Status
-Client::get(const ID id, stack::ipv4::Address& ripaddr,
-            stack::tcpv4::Port& lport, stack::tcpv4::Port& rport)
-{
-  /*
-   * Check if connection ID is valid.
-   */
-  if (id >= m_nconn) {
-    return Status::InvalidConnection;
-  }
-  /*
-   * Get the info.
-   */
-  return m_tcp.get(id, ripaddr, lport, rport);
 }
 
 system::Clock::Value

--- a/src/ssl/Client.cpp
+++ b/src/ssl/Client.cpp
@@ -32,7 +32,7 @@ Client::Client(system::Logger& log, api::interface::Client::Delegate& delegate,
                const size_t nconn, const bool save_keys)
   : m_delegate(delegate)
   , m_log(log)
-  , m_client(std::make_unique<api::Client>(log, *this, device, nconn))
+  , m_client(log, *this, device, nconn)
   , m_context(nullptr)
   , m_savekeys(save_keys)
 {
@@ -106,7 +106,7 @@ Client::~Client()
 Status
 Client::open(const uint8_t options, ID& id)
 {
-  return m_client->open(options, id);
+  return m_client.open(options, id);
 }
 
 Status
@@ -115,7 +115,7 @@ Client::abort(const ID id)
   /*
    * Grab the context.
    */
-  void* cookie = m_client->cookie(id);
+  void* cookie = m_client.cookie(id);
   if (cookie == nullptr) {
     return Status::InvalidArgument;
   }
@@ -129,7 +129,7 @@ Client::abort(const ID id)
   /*
    * Abort the connection.
    */
-  return m_client->abort(id);
+  return m_client.abort(id);
 }
 
 Status
@@ -138,7 +138,7 @@ Client::close(const ID id)
   /*
    * Grab the context.
    */
-  void* cookie = m_client->cookie(id);
+  void* cookie = m_client.cookie(id);
   if (cookie == nullptr) {
     return Status::NotConnected;
   }
@@ -171,7 +171,7 @@ Client::close(const ID id)
     }
     case 1: {
       m_log.debug("SSLCLI", "shutdown completed");
-      return m_client->close(id);
+      return m_client.close(id);
     }
     default: {
       auto err = SSL_get_error(c.ssl, ret);
@@ -185,13 +185,13 @@ Client::close(const ID id)
 Status
 Client::setHostName(const ID id, std::string_view hn)
 {
-  return m_client->setHostName(id, hn);
+  return m_client.setHostName(id, hn);
 }
 
 Status
 Client::getHostName(const ID id, std::optional<std::string>& hn)
 {
-  return m_client->getHostName(id, hn);
+  return m_client.getHostName(id, hn);
 }
 
 Status
@@ -199,16 +199,16 @@ Client::connect(const ID id, stack::ipv4::Address const& ripaddr,
                 const stack::tcpv4::Port rport)
 {
 
-  void* cookie = m_client->cookie(id);
+  void* cookie = m_client.cookie(id);
   /*
    * If the cookie is nullptr, we are not connected yet.
    */
   if (cookie == nullptr) {
-    Status res = m_client->connect(id, ripaddr, rport);
+    Status res = m_client.connect(id, ripaddr, rport);
     if (res != Status::Ok) {
       return res;
     }
-    cookie = m_client->cookie(id);
+    cookie = m_client.cookie(id);
   }
   /*
    * Perform the handshake.
@@ -226,7 +226,7 @@ Client::connect(const ID id, stack::ipv4::Address const& ripaddr,
      */
     case Context::State::Open: {
       std::optional<std::string> hostname;
-      m_client->getHostName(id, hostname);
+      m_client.getHostName(id, hostname);
       /*
        * Set the host name for SNI-enabled servers.
        */
@@ -300,7 +300,7 @@ Client::connect(const ID id, stack::ipv4::Address const& ripaddr,
 bool
 Client::isClosed(const ID id) const
 {
-  return m_client->isClosed(id);
+  return m_client.isClosed(id);
 }
 
 Status
@@ -316,7 +316,7 @@ Client::send(const ID id, const uint32_t len, const uint8_t* const data,
   /*
    * Grab the context.
    */
-  void* cookie = m_client->cookie(id);
+  void* cookie = m_client.cookie(id);
   if (cookie == nullptr) {
     return Status::InvalidArgument;
   }
@@ -366,7 +366,7 @@ Client::send(const ID id, const uint32_t len, const uint8_t* const data,
 system::Clock::Value
 Client::averageLatency(const ID id)
 {
-  return m_client->averageLatency(id);
+  return m_client.averageLatency(id);
 }
 
 void*
@@ -379,7 +379,7 @@ Client::onConnected(ID const& id, void* const cookie, const Timestamp ts)
   if (m_savekeys) {
     stack::ipv4::Address ip;
     stack::tcpv4::Port lport, rport;
-    m_client->get(id, ip, lport, rport);
+    m_client.get(id, ip, lport, rport);
     auto path = ip.toString();
     path.append("_");
     path.append(std::to_string(lport));
@@ -487,7 +487,7 @@ Client::flush(const ID id, void* const cookie)
    * Send the pending data.
    */
   uint32_t rem = 0;
-  Status res = m_client->send(id, len, ssl::bio::readAt(c.bout), rem);
+  Status res = m_client.send(id, len, ssl::bio::readAt(c.bout), rem);
   if (res != Status::Ok) {
     c.blocked = res == Status::OperationInProgress;
     return res;

--- a/src/ssl/Client.cpp
+++ b/src/ssl/Client.cpp
@@ -304,6 +304,13 @@ Client::isClosed(const ID id) const
 }
 
 Status
+Client::get(const ID id, stack::ipv4::Address& ripaddr,
+            stack::tcpv4::Port& lport, stack::tcpv4::Port& rport) const
+{
+  return m_client.get(id, ripaddr, lport, rport);
+}
+
+Status
 Client::send(const ID id, const uint32_t len, const uint8_t* const data,
              uint32_t& off)
 {

--- a/src/ssl/Client.cpp
+++ b/src/ssl/Client.cpp
@@ -103,6 +103,12 @@ Client::~Client()
   SSL_CTX_free(AS_SSL(m_context));
 }
 
+bool
+Client::live() const
+{
+  return m_client.live();
+}
+
 Status
 Client::open(const uint8_t options, ID& id)
 {

--- a/src/ssl/Client.cpp
+++ b/src/ssl/Client.cpp
@@ -295,6 +295,12 @@ Client::connect(const ID id, stack::ipv4::Address const& ripaddr,
       return Status::InvalidArgument;
     }
   }
+    /*
+     * Make GCC happy.
+     */
+#if defined(__GNUC__) && defined(__GNUC_PREREQ)
+  return Status::Ok;
+#endif
 }
 
 bool

--- a/src/ssl/Context.cpp
+++ b/src/ssl/Context.cpp
@@ -20,6 +20,7 @@ getMethod(const Protocol type, const bool server, long& flags)
     case Protocol::Auto: {
       method = server ? TLS_server_method() : TLS_client_method();
       flags = SSL_OP_NO_SSLv2 | SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1;
+      break;
     }
     case Protocol::SSLv3: {
       method = server ? SSLv23_server_method() : SSLv23_client_method();

--- a/src/stack/tcpv4/Client.cpp
+++ b/src/stack/tcpv4/Client.cpp
@@ -366,7 +366,7 @@ Processor::send(const Connection::ID id, const uint32_t len,
 
 Status
 Processor::get(const Connection::ID id, ipv4::Address& ripaddr, Port& lport,
-               Port& rport)
+               Port& rport) const
 {
   /*
    * Check if the connection is valid.
@@ -374,7 +374,13 @@ Processor::get(const Connection::ID id, ipv4::Address& ripaddr, Port& lport,
   if (id >= m_nconn) {
     return Status::InvalidConnection;
   }
-  Connection& c = m_conns[id];
+  /*
+   * Get the connection.
+   */
+  Connection const& c = m_conns[id];
+  /*
+   * Check the connection's state.
+   */
   if (c.m_state != Connection::ESTABLISHED) {
     return Status::NotConnected;
   }

--- a/src/stack/tcpv4/Client.cpp
+++ b/src/stack/tcpv4/Client.cpp
@@ -18,11 +18,14 @@ namespace tulips::stack::tcpv4 {
 uint16_t
 Processor::findLocalPort() const
 {
+  /*
+   * Look for a free port.
+   */
   while (true) {
     /*
      * Compute a local port value.
      */
-    auto lport = system::Clock::read() & 0x3FFF + 10000;
+    auto lport = (system::Clock::read() & 0x3FFF) + 10000;
     /*
      * Find a match.
      */
@@ -37,6 +40,12 @@ Processor::findLocalPort() const
       return lport;
     }
   }
+  /*
+   * Make GCC happy.
+   */
+#if defined(__GNUC__) && defined(__GNUC_PREREQ)
+  return 0;
+#endif
 }
 
 Status

--- a/src/transport/ena/AbstractionLayer.cpp
+++ b/src/transport/ena/AbstractionLayer.cpp
@@ -1,3 +1,4 @@
+#include "tulips/system/Logger.h"
 #include <tulips/transport/ena/AbstractionLayer.h>
 #include <cstdio>
 #include <mutex>
@@ -6,9 +7,6 @@
 #include <dpdk/rte_log.h>
 
 namespace {
-
-static std::once_flag s_setup;
-static std::once_flag s_cleanup;
 
 ssize_t
 logWrite(void* cookie, const char* buf, size_t size)
@@ -22,58 +20,55 @@ logWrite(void* cookie, const char* buf, size_t size)
 
 namespace tulips::transport::ena {
 
-AbstractionLayer::AbstractionLayer(system::Logger& logger)
-  : m_args(), m_logfile(nullptr)
+AbstractionLayer::Ref
+AbstractionLayer::allocate(system::Logger& log)
 {
-  std::call_once(s_setup, [this, &logger]() {
-    /*
-     * Build the arguments.
-     *
-     * NOTE(xrg): using a static variable does not work, for some reason
-     * rte_eal_init SIGSEGV when assigning the last item of the array.
-     */
-    m_args[0] = (char*)"dpdk";
-    // m_args[1] = (char*)"--in-memory";
-    // m_args[2] = (char*)"--no-telemetry";
-    // m_args[3] = (char*)"-c";
-    // m_args[4] = (char*)"1";
-    // m_args[5] = (char*)"--log-level=*:6";
-    m_args[1] = nullptr;
-    /*
-     * Define the cookie IOs.
-     */
-    cookie_io_functions_t ios = {
-      .read = nullptr,
-      .write = logWrite,
-      .seek = nullptr,
-      .close = nullptr,
-    };
-    /*
-     * Create the pseudo log file.
-     */
-    this->m_logfile = fopencookie(&logger, "w", ios);
-    /*
-     * Open the pseudo log stream.
-     */
-    rte_openlog_stream(this->m_logfile);
-    /*
-     * Initialize the abstraction layer.
-     */
-    int ret = rte_eal_init(1, (char**)m_args);
-    if (ret < 0) {
-      throw std::runtime_error("Failed to initialize EAL");
-    }
-  });
+  /*
+   * Define the cookie IOs.
+   */
+  cookie_io_functions_t ios = {
+    .read = nullptr,
+    .write = logWrite,
+    .seek = nullptr,
+    .close = nullptr,
+  };
+  /*
+   * Create the pseudo log file.
+   */
+  auto logfile = fopencookie(&log, "w", ios);
+  /*
+   * Buile the EAL.
+   */
+  return Ref(new AbstractionLayer(logfile));
+}
+
+AbstractionLayer::AbstractionLayer(FILE* const logfile) : m_logfile(logfile)
+{
+  /*
+   * Define the arguments.
+   */
+  const char* const ARGUMENTS[7] = {
+    (char*)"dpdk", (char*)"--in-memory", (char*)"--no-telemetry",
+    (char*)"-c",   (char*)"1",           (char*)"--log-level=*:6",
+    nullptr,
+  };
+  /*
+   * Open the pseudo log stream.
+   */
+  rte_openlog_stream(logfile);
+  /*
+   * Initialize the abstraction layer.
+   */
+  int ret = rte_eal_init(6, (char**)ARGUMENTS);
+  if (ret < 0) {
+    throw std::runtime_error("Failed to initialize EAL");
+  }
 }
 
 AbstractionLayer::~AbstractionLayer()
 {
-  std::call_once(s_cleanup, [this]() {
-    if (m_logfile != nullptr) {
-      rte_eal_cleanup();
-      fclose(m_logfile);
-    }
-  });
+  rte_eal_cleanup();
+  fclose(m_logfile);
 }
 
 }

--- a/src/transport/ena/AbstractionLayer.cpp
+++ b/src/transport/ena/AbstractionLayer.cpp
@@ -1,4 +1,4 @@
-#include "tulips/system/Logger.h"
+#include <tulips/system/Logger.h>
 #include <tulips/transport/ena/AbstractionLayer.h>
 #include <cstdio>
 #include <mutex>

--- a/src/transport/ena/AbstractionLayer.cpp
+++ b/src/transport/ena/AbstractionLayer.cpp
@@ -22,12 +22,23 @@ logWrite(void* cookie, const char* buf, size_t size)
 
 namespace tulips::transport::ena {
 
-AbstractionLayer::AbstractionLayer(system::Logger& logger) : m_logfile(nullptr)
+AbstractionLayer::AbstractionLayer(system::Logger& logger)
+  : m_args(), m_logfile(nullptr)
 {
   std::call_once(s_setup, [this, &logger]() {
-    const char* const arguments[] = {
-      "dpdk", "--in-memory", "--no-telemetry", "-c", "1", "--log-level=*:6"
-    };
+    /*
+     * Build the arguments.
+     *
+     * NOTE(xrg): using a static variable does not work, for some reason
+     * rte_eal_init SIGSEGV when assigning the last item of the array.
+     */
+    m_args[0] = (char*)"dpdk";
+    // m_args[1] = (char*)"--in-memory";
+    // m_args[2] = (char*)"--no-telemetry";
+    // m_args[3] = (char*)"-c";
+    // m_args[4] = (char*)"1";
+    // m_args[5] = (char*)"--log-level=*:6";
+    m_args[1] = nullptr;
     /*
      * Define the cookie IOs.
      */
@@ -48,7 +59,7 @@ AbstractionLayer::AbstractionLayer(system::Logger& logger) : m_logfile(nullptr)
     /*
      * Initialize the abstraction layer.
      */
-    int ret = rte_eal_init(6, (char**)arguments);
+    int ret = rte_eal_init(1, (char**)m_args);
     if (ret < 0) {
       throw std::runtime_error("Failed to initialize EAL");
     }

--- a/src/transport/ena/Port.cpp
+++ b/src/transport/ena/Port.cpp
@@ -27,7 +27,6 @@ namespace tulips::transport::ena {
 Port::Port(system::Logger& log, [[maybe_unused]] std::string_view ifn,
            [[maybe_unused]] const size_t width, const size_t depth)
   : m_log(log)
-  , m_eal(log)
   , m_depth(depth)
   , m_portid(0xFFFF)
   , m_address()

--- a/src/transport/ena/Port.cpp
+++ b/src/transport/ena/Port.cpp
@@ -41,7 +41,6 @@ Port::Port(system::Logger& log, [[maybe_unused]] std::string_view ifn,
   , m_admin()
   , m_raw()
 {
-#if 0
   int ret = 0;
   /*
    * Collect the available ports.
@@ -149,7 +148,6 @@ Port::Port(system::Logger& log, [[maybe_unused]] std::string_view ifn,
    * Allocate the admin device.
    */
   m_admin = next();
-#endif
 }
 
 Port::~Port()
@@ -157,9 +155,7 @@ Port::~Port()
   /*
    * Stop the device.
    */
-#if 0
   rte_eth_dev_stop(m_portid);
-#endif
   /*
    * Clear the TX mempools.
    */

--- a/src/transport/ena/Port.cpp
+++ b/src/transport/ena/Port.cpp
@@ -24,8 +24,8 @@ log2(const uint64_t x)
 
 namespace tulips::transport::ena {
 
-Port::Port(system::Logger& log, std::string_view ifn, const size_t width,
-           const size_t depth)
+Port::Port(system::Logger& log, [[maybe_unused]] std::string_view ifn,
+           [[maybe_unused]] const size_t width, const size_t depth)
   : m_log(log)
   , m_eal(log)
   , m_depth(depth)
@@ -42,7 +42,7 @@ Port::Port(system::Logger& log, std::string_view ifn, const size_t width,
   , m_admin()
   , m_raw()
 {
-
+#if 0
   int ret = 0;
   /*
    * Collect the available ports.
@@ -150,6 +150,7 @@ Port::Port(system::Logger& log, std::string_view ifn, const size_t width,
    * Allocate the admin device.
    */
   m_admin = next();
+#endif
 }
 
 Port::~Port()
@@ -157,7 +158,9 @@ Port::~Port()
   /*
    * Stop the device.
    */
+#if 0
   rte_eth_dev_stop(m_portid);
+#endif
   /*
    * Clear the TX mempools.
    */

--- a/src/transport/ena/Port.cpp
+++ b/src/transport/ena/Port.cpp
@@ -24,8 +24,8 @@ log2(const uint64_t x)
 
 namespace tulips::transport::ena {
 
-Port::Port(system::Logger& log, [[maybe_unused]] std::string_view ifn,
-           [[maybe_unused]] const size_t width, const size_t depth)
+Port::Port(system::Logger& log, std::string_view ifn, const size_t width,
+           const size_t depth)
   : m_log(log)
   , m_depth(depth)
   , m_portid(0xFFFF)

--- a/src/transport/ofed/Device.cpp
+++ b/src/transport/ofed/Device.cpp
@@ -669,7 +669,6 @@ Device::prepare(uint8_t*& buf)
   for (int i = 0; i < cqn; i += 1) {
     uint16_t len = wc[i].byte_len;
     auto* addr = (uint8_t*)wc[i].wr_id; // NOLINT
-    auto info = SentBuffer(len, addr);
     m_sent.emplace_back(len, addr);
   }
   /*

--- a/tools/uspace/ena/CMakeLists.txt
+++ b/tools/uspace/ena/CMakeLists.txt
@@ -16,7 +16,8 @@ add_executable(ena-uspace ${SOURCES}
   $<TARGET_OBJECTS:utils>)
 
 target_link_libraries(ena-uspace
-  PUBLIC
+  PRIVATE
   tulips_transport_ena
   tulips_transport_pcap
-  tulips_api)
+  tulips_api
+  tulips_ssl)

--- a/tools/uspace/ena/Client.cpp
+++ b/tools/uspace/ena/Client.cpp
@@ -76,6 +76,7 @@ try {
   TCLAP::ValueArg<std::string> iffA("I", "interface", "Network interface", true,
                                     "", "INTERFACE", cmdL);
   TCLAP::SwitchArg pcpA("P", "pcap", "Capture packets", cmdL);
+  TCLAP::SwitchArg sslA("S", "ssl", "Use SSL", cmdL);
   cmdL.parse(argc, argv);
   /*
    * Linenoise.
@@ -86,7 +87,7 @@ try {
   /*
    * Commands.
    */
-  ena::State state(iffA.getValue(), pcpA.isSet());
+  ena::State state(iffA.getValue(), pcpA.isSet(), sslA.isSet());
   basic::populate(state.commands);
   ena::connection::populate(state.commands);
   ena::poller::populate(state.commands);

--- a/tools/uspace/ena/Poller.cpp
+++ b/tools/uspace/ena/Poller.cpp
@@ -1,6 +1,6 @@
-#include "tulips/ssl/Protocol.h"
 #include <tulips/api/Client.h>
 #include <tulips/ssl/Client.h>
+#include <tulips/ssl/Protocol.h>
 #include <tulips/transport/Device.h>
 #include <iostream>
 #include <linenoise/linenoise.h>

--- a/tools/uspace/ena/Poller.h
+++ b/tools/uspace/ena/Poller.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <tulips/api/Client.h>
 #include <tulips/api/Defaults.h>
 #include <tulips/system/Logger.h>
 #include <tulips/transport/Device.h>
@@ -18,7 +17,7 @@ class Poller
 public:
   using Ref = std::unique_ptr<Poller>;
 
-  Poller(system::Logger& log, transport::Device::Ref dev, const bool pcap);
+  Poller(system::Logger& log, transport::Device::Ref dev, const bool pcap, const bool ssl);
   Poller(Poller&&) = default;
   ~Poller();
 
@@ -56,7 +55,7 @@ private:
   transport::pcap::Device* m_pcap;
   transport::Device* m_device;
   api::defaults::ClientDelegate m_delegate;
-  api::Client m_client;
+  std::unique_ptr<api::interface::Client> m_client;
   volatile bool m_run;
   pthread_t m_thread;
   pthread_mutex_t m_mutex;

--- a/tools/uspace/ena/Poller.h
+++ b/tools/uspace/ena/Poller.h
@@ -17,7 +17,8 @@ class Poller
 public:
   using Ref = std::unique_ptr<Poller>;
 
-  Poller(system::Logger& log, transport::Device::Ref dev, const bool pcap, const bool ssl);
+  Poller(system::Logger& log, transport::Device::Ref dev, const bool pcap,
+         const bool ssl);
   Poller(Poller&&) = default;
   ~Poller();
 
@@ -36,6 +37,7 @@ private:
   {
     Connect,
     Close,
+    Closing,
     Info,
     Write,
     None

--- a/tools/uspace/ena/State.cpp
+++ b/tools/uspace/ena/State.cpp
@@ -1,4 +1,4 @@
-#include "tulips/transport/ena/AbstractionLayer.h"
+#include <tulips/transport/ena/AbstractionLayer.h>
 #include <chrono>
 #include <thread>
 #include <uspace/ena/State.h>

--- a/tools/uspace/ena/State.cpp
+++ b/tools/uspace/ena/State.cpp
@@ -4,11 +4,12 @@
 
 namespace tulips::tools::uspace::ena {
 
-State::State(std::string_view iff, const bool pcap)
+State::State(std::string_view iff, const bool pcap, const bool ssl)
   : utils::State()
   , interface(iff)
   , port(logger, iff, 8, 32)
   , with_pcap(pcap)
+  , with_ssl(ssl)
   , pollers()
   , m_run(true)
   , m_thread()

--- a/tools/uspace/ena/State.cpp
+++ b/tools/uspace/ena/State.cpp
@@ -1,3 +1,4 @@
+#include "tulips/transport/ena/AbstractionLayer.h"
 #include <chrono>
 #include <thread>
 #include <uspace/ena/State.h>
@@ -7,6 +8,7 @@ namespace tulips::tools::uspace::ena {
 State::State(std::string_view iff, const bool pcap, const bool ssl)
   : utils::State()
   , interface(iff)
+  , eal(transport::ena::AbstractionLayer::allocate(logger))
   , port(logger, iff, 8, 32)
   , with_pcap(pcap)
   , with_ssl(ssl)

--- a/tools/uspace/ena/State.h
+++ b/tools/uspace/ena/State.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <tulips/transport/Processor.h>
+#include <tulips/transport/ena/AbstractionLayer.h>
 #include <tulips/transport/ena/Device.h>
 #include <tulips/transport/ena/Port.h>
 #include <map>
@@ -20,6 +21,7 @@ public:
   ~State() override;
 
   std::string interface;
+  transport::ena::AbstractionLayer::Ref eal;
   transport::ena::Port port;
   bool with_pcap;
   bool with_ssl;

--- a/tools/uspace/ena/State.h
+++ b/tools/uspace/ena/State.h
@@ -15,12 +15,13 @@ using IDs = std::map<api::Client::ID, size_t>;
 class State : public utils::State
 {
 public:
-  State(std::string_view iff, const bool pcap = false);
+  State(std::string_view iff, const bool pcap, const bool ssl);
   ~State() override;
 
   std::string interface;
   transport::ena::Port port;
   bool with_pcap;
+  bool with_ssl;
   std::vector<poller::Poller::Ref> pollers;
   IDs ids;
 

--- a/tools/uspace/ena/State.h
+++ b/tools/uspace/ena/State.h
@@ -4,13 +4,14 @@
 #include <tulips/transport/ena/Device.h>
 #include <tulips/transport/ena/Port.h>
 #include <map>
+#include <set>
 #include <string>
 #include <uspace/ena/Poller.h>
 #include <utils/State.h>
 
 namespace tulips::tools::uspace::ena {
 
-using IDs = std::map<api::Client::ID, size_t>;
+using IDs = std::map<size_t, std::set<api::Client::ID>>;
 
 class State : public utils::State
 {


### PR DESCRIPTION
Generates the build definitions so that applications that use the library can use them.